### PR TITLE
feat: create public initialize method to initialize the SDK

### DIFF
--- a/DevCycleTests/DVCClientTest.swift
+++ b/DevCycleTests/DVCClientTest.swift
@@ -42,7 +42,7 @@ class DVCClientTest: XCTestCase {
         let service = MockService() // will assert if getConfig was called
         client.setEnvironmentKey("")
         client.setUser(getTestUser())
-        client.setup(service)
+        client.setup(service: service)
     }
 }
 


### PR DESCRIPTION
# Summary

Instead of setting up the client object when the user builds the object, have the user call a public method `initialize` with a callback to let the user initialize the SDK.