### PR TITLE
[DVC-1271] chore: make build function throwable

### DIFF
--- a/DevCycle/DVCClient.swift
+++ b/DevCycle/DVCClient.swift
@@ -121,14 +121,14 @@ public class DVCClient {
             return self
         }
         
-        public func build() -> DVCClient? {
+        public func build() throws -> DVCClient {
             guard self.client.environmentKey != nil else {
                 print("Missing Environment Key")
-                return nil
+                throw ClientError.MissingEnvironmentKeyOrUser
             }
             guard self.client.user != nil else {
                 print("Missing User")
-                return nil
+                throw ClientError.MissingEnvironmentKeyOrUser
             }
             
             let result = self.client

--- a/DevCycle/DVCUser.swift
+++ b/DevCycle/DVCUser.swift
@@ -6,6 +6,12 @@
 
 import Foundation
 
+enum UserError: Error {
+    case MissingUserId
+    case MissingUserIdAndIsAnonymousFalse
+    case InvalidUser
+}
+
 public class DVCUser: Codable {
     public var userId: String?
     public var isAnonymous: Bool?
@@ -101,10 +107,13 @@ public class DVCUser: Codable {
             return self
         }
         
-        public func build() -> DVCUser? {
-            guard let _ = self.user.userId, let _ = self.user.isAnonymous else {
-                return nil
+        public func build() throws -> DVCUser {
+            guard let _ = self.user.userId,
+                  let _ = self.user.isAnonymous
+            else {
+                throw UserError.MissingUserIdAndIsAnonymousFalse
             }
+
             
             let result = self.user
             self.user = DVCUser()

--- a/DevCycle/ObjC/ObjCDVCClient.swift
+++ b/DevCycle/ObjC/ObjCDVCClient.swift
@@ -30,7 +30,7 @@ public class ObjCDVCClient: NSObject {
             }
             return
         }
-        guard let client = DVCClient.builder()
+        guard let client = try? DVCClient.builder()
                 .environmentKey(environmentKey)
                 .user(user)
                 .build()

--- a/DevCycle/ObjC/ObjCDVCUser.swift
+++ b/DevCycle/ObjC/ObjCDVCUser.swift
@@ -91,7 +91,7 @@ public class ObjCDVCUser: NSObject {
         if let publicCustomData = builder.publicCustomData {
             userBuilder = userBuilder.publicCustomData(publicCustomData)
         }
-        guard let user = userBuilder.build() else {
+        guard let user = try? userBuilder.build() else {
             print("Error making user")
             throw ObjCUserErrors.InvalidUser
         }

--- a/DevCycleTests/DVCClientTest.swift
+++ b/DevCycleTests/DVCClientTest.swift
@@ -9,21 +9,21 @@ import XCTest
 
 class DVCClientTest: XCTestCase {
     func testBuilderReturnsNilIfNoEnvKey() {
-        let user = DVCUser.builder()
+        let user = try! DVCUser.builder()
                     .userId("my_user")
-                    .build()!
-        XCTAssertNil(DVCClient.builder().user(user).build())
+                    .build()
+        XCTAssertNil(try? DVCClient.builder().user(user).build())
     }
     
     func testBuilderReturnsNilIfNoUser() {
-        XCTAssertNil(DVCClient.builder().environmentKey("my_env_key").build())
+        XCTAssertNil(try? DVCClient.builder().environmentKey("my_env_key").build())
     }
     
     func testBuilderReturnsClient() {
-        let user = DVCUser.builder()
+        let user = try! DVCUser.builder()
                     .userId("my_user")
-                    .build()!
-        let client = DVCClient.builder().user(user).environmentKey("my_env_key").build()!
+                    .build()
+        let client = try! DVCClient.builder().user(user).environmentKey("my_env_key").build()
         XCTAssertNotNil(client)
         XCTAssertNotNil(client.user)
         XCTAssertNotNil(client.environmentKey)
@@ -39,11 +39,9 @@ class DVCClientTest: XCTestCase {
     }
     
     func testBuilderReturnsClientWithOptions() {
-        let user = DVCUser.builder()
-                    .userId("my_user")
-                    .build()!
+        let user = getTestUser()
         let options = DVCOptions.builder().disableEventLogging(false).flushEventsIntervalMs(100).build()
-        let client = DVCClient.builder().user(user).environmentKey("my_env_key").options(options).build()!
+        let client = try! DVCClient.builder().user(user).environmentKey("my_env_key").options(options).build()
         XCTAssertNotNil(client)
         XCTAssertNotNil(client.options)
         XCTAssertNotNil(client.user)
@@ -76,8 +74,8 @@ extension DVCClientTest {
     }
     
     func getTestUser() -> DVCUser {
-        return DVCUser.builder()
+        return try! DVCUser.builder()
             .userId("my_user")
-            .build()!
+            .build()
     }
 }

--- a/DevCycleTests/DVCUserTest.swift
+++ b/DevCycleTests/DVCUserTest.swift
@@ -20,20 +20,20 @@ class DVCUserTest: XCTestCase {
     }
 
     func testBuilderReturnsNilIfNoUserIdOrIsAnonymous() {
-        let user = DVCUser.builder()
+        let user = try? DVCUser.builder()
                     .build()
         XCTAssertNil(user)
     }
     
     func testBuilderReturnsUserIfUserIdSet() {
-        let user = DVCUser.builder().userId("my_user").build()!
+        let user = try! DVCUser.builder().userId("my_user").build()
         XCTAssertNotNil(user)
         XCTAssert(user.userId == "my_user")
         XCTAssert(!user.isAnonymous!)
     }
     
     func testBuilderReturnsUserIfIsAnonymousSet() {
-        let user = DVCUser.builder().isAnonymous(true).build()!
+        let user = try! DVCUser.builder().isAnonymous(true).build()
         XCTAssertNotNil(user)
         XCTAssert(user.isAnonymous!)
         XCTAssert(UUID(uuidString: user.userId!) != nil)
@@ -66,10 +66,10 @@ class DVCUserTest: XCTestCase {
 
 extension DVCUserTest {
     func getTestUser() -> DVCUser {
-        return DVCUser.builder()
+        return try! DVCUser.builder()
             .userId("my_user")
             .isAnonymous(false)
             .customData(["custom": "key"])
-            .build()!
+            .build()
     }
 }

--- a/DevCycleTests/DevCycleServiceTests.swift
+++ b/DevCycleTests/DevCycleServiceTests.swift
@@ -76,8 +76,8 @@ extension DevCycleServiceTests {
     }
     
     func getTestUser() -> DVCUser {
-        return DVCUser.builder()
+        return try! DVCUser.builder()
             .userId("my_user")
-            .build()!
+            .build()
     }
 }


### PR DESCRIPTION
# Summary

Make `build` function throw with proper errors if user omits environment key or user for `DVCClient`, or not set a `userId` or `isAnonymous` for `DVCUser`.

# Blocked by PR

#10 