### PR TITLE
DVC-1955 Update Obj-C SDK interface

### DIFF
--- a/DevCycle-iOS.xcodeproj/project.pbxproj
+++ b/DevCycle-iOS.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0F2DD75A279EFA6B00540C9D /* CustomData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F2DD759279EFA6B00540C9D /* CustomData.swift */; };
 		524D58242770F78B00D7CC56 /* ObjCDVCVariable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 524D58232770F78B00D7CC56 /* ObjCDVCVariable.swift */; };
 		524F4E60276BDDBD00CB9069 /* DVCVariable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 524F4E5F276BDDBD00CB9069 /* DVCVariable.swift */; };
 		524F4E62276D20A600CB9069 /* DVCVariableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 524F4E61276D20A500CB9069 /* DVCVariableTests.swift */; };
@@ -51,6 +52,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		0F2DD759279EFA6B00540C9D /* CustomData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomData.swift; sourceTree = "<group>"; };
 		524D58232770F78B00D7CC56 /* ObjCDVCVariable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ObjCDVCVariable.swift; sourceTree = "<group>"; };
 		524F4E5F276BDDBD00CB9069 /* DVCVariable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DVCVariable.swift; sourceTree = "<group>"; };
 		524F4E61276D20A500CB9069 /* DVCVariableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DVCVariableTests.swift; sourceTree = "<group>"; };
@@ -212,6 +214,7 @@
 				D9341C11276967DE00BC753F /* DVCEvent.swift */,
 				5264A7BC2769381500FEDB43 /* Cache.swift */,
 				52A9698F279F3AAA00D3A602 /* PlatformDetails.swift */,
+				0F2DD759279EFA6B00540C9D /* CustomData.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -329,6 +332,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				5264A78B2763F6D800FEDB43 /* UserConfig.swift in Sources */,
+				0F2DD75A279EFA6B00540C9D /* CustomData.swift in Sources */,
 				5264A781275EB7DC00FEDB43 /* ObjCDVCUser.swift in Sources */,
 				52A96990279F3AAA00D3A602 /* PlatformDetails.swift in Sources */,
 				52A48707278C9BE200DABA34 /* Log.swift in Sources */,

--- a/DevCycle/DVCUser.swift
+++ b/DevCycle/DVCUser.swift
@@ -13,8 +13,96 @@ import UIKit
 enum UserError: Error {
     case MissingUserId
     case MissingUserIdAndIsAnonymousFalse
+    case InvalidCustomDataJSON
+    case InvalidPrivateCustomDataJSON
     case InvalidUser
 }
+
+public class UserBuilder {
+    var user: DVCUser
+    
+    init() {
+        self.user = DVCUser()
+    }
+    
+    public func userId(_ userId: String) -> UserBuilder {
+        self.user.userId = userId
+        self.user.isAnonymous = false
+        return self
+    }
+    
+    public func isAnonymous(_ isAnonymous: Bool) -> UserBuilder {
+        if (self.user.isAnonymous != nil) { return self }
+        self.user.isAnonymous = isAnonymous
+        self.user.userId = UUID().uuidString
+        return self
+    }
+    
+    public func email(_ email: String) -> UserBuilder {
+        self.user.email = email
+        return self
+    }
+    
+    public func name(_ name: String) -> UserBuilder {
+        self.user.name = name
+        return self
+    }
+    
+    public func language(_ language: String) -> UserBuilder {
+        self.user.language = language
+        return self
+    }
+    
+    public func country(_ country: String) -> UserBuilder {
+        self.user.country = country
+        return self
+    }
+    
+    public func appVersion(_ appVersion: String) -> UserBuilder {
+        self.user.appVersion = appVersion
+        return self
+    }
+    
+    public func appBuild(_ appBuild: Int) -> UserBuilder {
+        self.user.appBuild = appBuild
+        return self
+    }
+    
+    public func customData(_ customData: CustomData) -> UserBuilder {
+        self.user.customData = customData
+        return self
+    }
+    
+    public func privateCustomData(_ privateCustomData: CustomData) -> UserBuilder {
+        self.user.privateCustomData = privateCustomData
+        return self
+    }
+    
+    public func build() throws -> DVCUser {
+        guard let _ = self.user.userId,
+              let _ = self.user.isAnonymous
+        else {
+            throw UserError.MissingUserIdAndIsAnonymousFalse
+        }
+        
+        if let customData = self.user.customData {
+            guard let _ = try? JSONEncoder().encode(customData) else {
+                throw UserError.InvalidCustomDataJSON
+            }
+        }
+        
+        if let privateCustomData = self.user.privateCustomData {
+            guard let _ = try? JSONEncoder().encode(privateCustomData) else {
+                throw UserError.InvalidPrivateCustomDataJSON
+            }
+        }
+        
+        let result = self.user
+        self.user = DVCUser()
+        return result
+    }
+}
+
 
 public class DVCUser: Codable {
     public var userId: String?
@@ -25,8 +113,8 @@ public class DVCUser: Codable {
     public var country: String?
     public var appVersion: String?
     public var appBuild: Int?
-    public var customData: Data?
-    public var privateCustomData: Data?
+    public var customData: CustomData?
+    public var privateCustomData: CustomData?
     public var lastSeenDate: Date
     public let createdDate: Date
     public let platform: String
@@ -63,137 +151,8 @@ public class DVCUser: Codable {
         self.privateCustomData = user.privateCustomData
     }
     
-    func update(with user: ObjCDVCUser) {
-        self.userId = user.userId
-        self.isAnonymous = user.isAnonymous != nil ? Bool(truncating: user.isAnonymous!) : false
-        self.lastSeenDate = Date()
-        self.email = user.email
-        self.name = user.name
-        self.language = user.language
-        self.country = user.country
-        self.appVersion = user.appVersion
-        self.appBuild = user.appBuild?.intValue
-        if let customData = user.customData, let data = try? JSONSerialization.data(withJSONObject: customData, options: []) {
-            self.customData = data
-        }
-        if let privateCustomData = user.privateCustomData, let data = try? JSONSerialization.data(withJSONObject: privateCustomData, options: []) {
-            self.privateCustomData = data
-        }
-    }
-    
-    public class UserBuilder {
-        var user: DVCUser
-        
-        init() {
-            self.user = DVCUser()
-        }
-        
-        public func userId(_ userId: String) -> UserBuilder {
-            self.user.userId = userId
-            self.user.isAnonymous = false
-            return self
-        }
-        
-        public func isAnonymous(_ isAnonymous: Bool) -> UserBuilder {
-            if (self.user.isAnonymous != nil) { return self }
-            self.user.isAnonymous = isAnonymous
-            self.user.userId = UUID().uuidString
-            return self
-        }
-        
-        public func email(_ email: String) -> UserBuilder {
-            self.user.email = email
-            return self
-        }
-        
-        public func name(_ name: String) -> UserBuilder {
-            self.user.name = name
-            return self
-        }
-        
-        public func language(_ language: String) -> UserBuilder {
-            self.user.language = language
-            return self
-        }
-        
-        public func country(_ country: String) -> UserBuilder {
-            self.user.country = country
-            return self
-        }
-        
-        public func appVersion(_ appVersion: String) -> UserBuilder {
-            self.user.appVersion = appVersion
-            return self
-        }
-        
-        public func appBuild(_ appBuild: Int) -> UserBuilder {
-            self.user.appBuild = appBuild
-            return self
-        }
-        
-        public func customData(_ customData: [String:Any]) -> UserBuilder {
-            guard let data = try? JSONSerialization.data(withJSONObject: customData, options: []) else {
-                return self
-            }
-            self.user.customData = data
-            return self
-        }
-        
-        public func privateCustomData(_ privateCustomData: [String:Any]) -> UserBuilder {
-            guard let data = try? JSONSerialization.data(withJSONObject: privateCustomData, options: []) else {
-                return self
-            }
-            self.user.privateCustomData = data
-            return self
-        }
-        
-        public func build() throws -> DVCUser {
-            guard let _ = self.user.userId,
-                  let _ = self.user.isAnonymous
-            else {
-                throw UserError.MissingUserIdAndIsAnonymousFalse
-            }
-
-            
-            let result = self.user
-            self.user = DVCUser()
-            return result
-        }
-    }
-    
     public static func builder() -> UserBuilder {
         return UserBuilder()
-    }
-}
-
-extension DVCUser {
-    class QueryItemBuilder {
-        var items: [URLQueryItem]
-        let user: DVCUser
-        
-        init(user: DVCUser) {
-            self.items = []
-            self.user = user
-        }
-        
-        func formatToQueryItem<T>(name: String, value: T?) -> QueryItemBuilder {
-            guard let property = value else { return self }
-            if let map = property as? Data {
-                items.append(URLQueryItem(name: name, value: String(data: map, encoding: String.Encoding.utf8)))
-            } else if let date = property as? Date {
-                items.append(URLQueryItem(name: name, value: "\(Int(date.timeIntervalSince1970))"))
-            } else {
-                items.append(URLQueryItem(name: name, value: "\(property)"))
-            }
-            
-            return self
-        }
-        
-        func build() -> [URLQueryItem] {
-            let result = self.items
-            self.items = []
-            return result
-        }
     }
     
     func toQueryItems() -> [URLQueryItem] {
@@ -206,8 +165,6 @@ extension DVCUser {
             .formatToQueryItem(name: "country", value: self.country)
             .formatToQueryItem(name: "appVersion", value: self.appVersion)
             .formatToQueryItem(name: "appBuild", value: self.appBuild)
-            .formatToQueryItem(name: "customData", value: self.customData)
-            .formatToQueryItem(name: "privateCustomData", value: self.privateCustomData)
             .formatToQueryItem(name: "lastSeenDate", value: self.lastSeenDate)
             .formatToQueryItem(name: "createdDate", value: self.createdDate)
             .formatToQueryItem(name: "platform", value: self.platform)
@@ -215,6 +172,45 @@ extension DVCUser {
             .formatToQueryItem(name: "deviceModel", value: self.deviceModel)
             .formatToQueryItem(name: "sdkType", value: self.sdkType)
             .formatToQueryItem(name: "sdkVersion", value: self.sdkVersion)
+        
+        if let customData = self.customData,
+           let customDataJSON = try? JSONEncoder().encode(customData) {
+            _ = builder.formatToQueryItem(name: "customData", value: customDataJSON)
+        }
+        if let privateCustomData = self.privateCustomData,
+           let privateCustomDataJSON = try? JSONEncoder().encode(privateCustomData) {
+            _ = builder.formatToQueryItem(name: "customData", value: privateCustomDataJSON)
+        }
+        
         return builder.build()
+    }
+}
+
+class QueryItemBuilder {
+    var items: [URLQueryItem]
+    let user: DVCUser
+    
+    init(user: DVCUser) {
+        self.items = []
+        self.user = user
+    }
+    
+    func formatToQueryItem<T>(name: String, value: T?) -> QueryItemBuilder {
+        guard let property = value else { return self }
+        if let map = property as? Data {
+            items.append(URLQueryItem(name: name, value: String(data: map, encoding: String.Encoding.utf8)))
+        } else if let date = property as? Date {
+            items.append(URLQueryItem(name: name, value: "\(Int(date.timeIntervalSince1970))"))
+        } else {
+            items.append(URLQueryItem(name: name, value: "\(property)"))
+        }
+        
+        return self
+    }
+    
+    func build() -> [URLQueryItem] {
+        let result = self.items
+        self.items = []
+        return result
     }
 }

--- a/DevCycle/DVCUser.swift
+++ b/DevCycle/DVCUser.swift
@@ -20,6 +20,8 @@ enum UserError: Error {
 
 public class UserBuilder {
     var user: DVCUser
+    var customData: [String: Any]?
+    var privateCustomData: [String: Any]?
     
     init() {
         self.user = DVCUser()
@@ -68,13 +70,13 @@ public class UserBuilder {
         return self
     }
     
-    public func customData(_ customData: CustomData) -> UserBuilder {
-        self.user.customData = customData
+    public func customData(_ customData: [String: Any]) -> UserBuilder {
+        self.customData = customData
         return self
     }
     
-    public func privateCustomData(_ privateCustomData: CustomData) -> UserBuilder {
-        self.user.privateCustomData = privateCustomData
+    public func privateCustomData(_ privateCustomData: [String: Any]) -> UserBuilder {
+        self.privateCustomData = privateCustomData
         return self
     }
     
@@ -85,20 +87,18 @@ public class UserBuilder {
             throw UserError.MissingUserIdAndIsAnonymousFalse
         }
         
-        if let customData = self.user.customData {
-            guard let _ = try? JSONEncoder().encode(customData) else {
-                throw UserError.InvalidCustomDataJSON
-            }
+        if let customData = self.customData {
+            self.user.customData = try CustomData.customDataFromDic(customData)
         }
         
-        if let privateCustomData = self.user.privateCustomData {
-            guard let _ = try? JSONEncoder().encode(privateCustomData) else {
-                throw UserError.InvalidPrivateCustomDataJSON
-            }
+        if let privateCustomData = self.privateCustomData {
+            self.user.privateCustomData = try CustomData.customDataFromDic(privateCustomData)
         }
         
         let result = self.user
         self.user = DVCUser()
+        self.customData = nil
+        self.privateCustomData = nil
         return result
     }
 }

--- a/DevCycle/Models/CustomData.swift
+++ b/DevCycle/Models/CustomData.swift
@@ -1,0 +1,101 @@
+//
+//  CustomData.swift
+//  DevCycle
+//
+
+import Foundation
+
+public enum CustomDataValue: Codable {
+    case string(_ value: String)
+    case number(_ value: Double)
+    case boolean(_ value: Bool)
+    
+    public init(from decoder: Decoder) throws {
+        let singleValueContainer = try decoder.singleValueContainer()
+
+        do {
+            let value = try singleValueContainer.decode(Double.self)
+            self = .number(value)
+            return
+        } catch {}
+        
+        do {
+            let value = try singleValueContainer.decode(Bool.self)
+            self = .boolean(value)
+            return
+        } catch {}
+        
+        do {
+            let value = try singleValueContainer.decode(String.self)
+            self = .string(value)
+            return
+        } catch {}
+        
+        throw DecodingError.dataCorruptedError(
+            in: singleValueContainer,
+            debugDescription: "Invalid CustomDataValue, must be a String / Number / Boolean type"
+        )
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .string(let value):
+            return try container.encode(value)
+        case .number(let value):
+            return try container.encode(value)
+        case .boolean(let value):
+            return try container.encode(value)
+        }
+    }
+}
+
+public class CustomData: Codable {
+    public var data: [String: CustomDataValue]
+    
+    public static func customDataFromDic(_ data: [String: Any]) throws -> CustomData {
+        let data = try JSONSerialization.data(withJSONObject: data)
+        let decoder = JSONDecoder()
+        return try decoder.decode(CustomData.self, from: data)
+    }
+    
+    required public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: DynamicCodingKeys.self)
+        var tmpData = [String: CustomDataValue]()
+        
+        for key in container.allKeys {
+            let decodedObject = try container.decode(
+                CustomDataValue.self,
+                forKey: DynamicCodingKeys(stringValue: key.stringValue)!
+            )
+            tmpData[key.stringValue] = decodedObject
+        }
+        self.data = tmpData
+    }
+    
+    private struct DynamicCodingKeys: CodingKey {
+        // Use for string-keyed dictionary
+        var stringValue: String
+        init?(stringValue: String) {
+            self.stringValue = stringValue
+        }
+
+        // Use for integer-keyed dictionary
+        var intValue: Int?
+        init?(intValue: Int) {
+            // We are not using this, thus just return nil
+            return nil
+        }
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: DynamicCodingKeys.self)
+        
+        for (key, value) in data {
+            try container.encode(
+                value,
+                forKey: DynamicCodingKeys(stringValue: key)!
+            )
+        }
+    }
+}

--- a/DevCycle/Networking/DevCycleService.swift
+++ b/DevCycle/Networking/DevCycleService.swift
@@ -153,7 +153,9 @@ class DevCycleService: DevCycleServiceProtocol {
         }
         self.session.dataTask(with: request) { data, response, error in
             DispatchQueue.main.async {
-                guard let responseDataJson = try? JSONSerialization.jsonObject(with: data!, options: .fragmentsAllowed) as? [String:Any] else {
+                guard let responseData = data,
+                      let responseDataJson = try? JSONSerialization.jsonObject(with: responseData, options: .fragmentsAllowed) as? [String:Any]
+                else {
                     Log.error("Unable to parse API Response", tags: ["api"])
                     completion?((nil, nil, APIError.NoResponse))
                     return

--- a/DevCycle/ObjC/ObjCDVCClient.swift
+++ b/DevCycle/ObjC/ObjCDVCClient.swift
@@ -134,35 +134,65 @@ public class ObjCDVCClient: NSObject {
         }
     }
     
-    @objc public func variable(key: String, defaultValue: Any) throws -> ObjCDVCVariable {
-        var variable: ObjCDVCVariable
-        if let variableFromConfig = self.client?.config?.userConfig?.variables[key] {
-            variable = try ObjCDVCVariable(
-                key: key,
-                type: variableFromConfig.type,
-                evalReason: variableFromConfig.evalReason,
-                value: variableFromConfig.value,
-                defaultValue: defaultValue
-            )
-        } else {
-            variable = try ObjCDVCVariable(
-                key: key,
-                type: nil,
-                evalReason: nil,
-                value: nil,
-                defaultValue: defaultValue
+    @objc public func stringVariable(key: String, defaultValue: String) -> ObjCDVCVariable {
+        return variable(key: key, defaultValue: defaultValue)
+    }
+    
+    @objc public func numberVariable(key: String, defaultValue: NSNumber) -> ObjCDVCVariable {
+        return variable(key: key, defaultValue: defaultValue)
+    }
+    
+    @objc public func boolVariable(key: String, defaultValue: Bool) -> ObjCDVCVariable {
+        return variable(key: key, defaultValue: defaultValue)
+    }
+    
+    @objc public func jsonVariable(key: String, defaultValue: NSObject) -> ObjCDVCVariable {
+        return variable(key: key, defaultValue: defaultValue)
+    }
+    
+    func variable<T>(key: String, defaultValue: T) -> ObjCDVCVariable {
+        guard let client = self.client else {
+            return ObjCDVCVariable(dvcVariable:
+                DVCVariable<T>(
+                    key: key,
+                    type: String(describing: T.self),
+                    value: nil,
+                    defaultValue: defaultValue,
+                    evalReason: nil
+                )
             )
         }
+
+        return ObjCDVCVariable(dvcVariable: client.variable(key: key, defaultValue: defaultValue))
         
-        client?.configCompletionHandlers.append({ error in
-            if let variableFromApi = self.client?.config?.userConfig?.variables[key] {
-                try? variable.update(from: variableFromApi)
-            }
-        })
-        
-        self.client?.updateAggregateEvents(variableKey: variable.key, variableIsDefaulted: variable.isDefaulted)
-        
-        return variable
+//        var variable: ObjCDVCVariable
+//        if let variableFromConfig = self.client?.config?.userConfig?.variables[key] {
+//            variable = try ObjCDVCVariable(
+//                key: key,
+//                type: variableFromConfig.type,
+//                evalReason: variableFromConfig.evalReason,
+//                value: variableFromConfig.value,
+//                defaultValue: defaultValue
+//            )
+//        } else {
+//            variable = try ObjCDVCVariable(
+//                key: key,
+//                type: nil,
+//                evalReason: nil,
+//                value: nil,
+//                defaultValue: defaultValue
+//            )
+//        }
+//
+//        client?.configCompletionHandlers.append({ error in
+//            if let variableFromApi = self.client?.config?.userConfig?.variables[key] {
+//                try? variable.update(from: variableFromApi)
+//            }
+//        })
+//
+//        self.client?.updateAggregateEvents(variableKey: variable.key, variableIsDefaulted: variable.isDefaulted)
+//
+//        return variable
     }
     
     @objc public func allFeatures() -> [String: ObjCFeature]? {

--- a/DevCycle/ObjC/ObjCDVCClient.swift
+++ b/DevCycle/ObjC/ObjCDVCClient.swift
@@ -58,7 +58,7 @@ public class ObjCDVCClient: NSObject {
         options: ObjCOptions?,
         onInitialized: ((Error?) -> Void)?
     ) throws {
-        if (environmentKey == nil) {
+        if (environmentKey == nil || environmentKey == "") {
             Log.error("Environment key missing", tags: ["build", "objc"])
             throw ObjCClientErrors.MissingEnvironmentKey
         } else if (user == nil) {

--- a/DevCycle/ObjC/ObjCDVCClient.swift
+++ b/DevCycle/ObjC/ObjCDVCClient.swift
@@ -152,7 +152,7 @@ public class ObjCDVCClient: NSObject {
     
     func variable<T>(key: String, defaultValue: T) -> ObjCDVCVariable {
         guard let client = self.client else {
-            return ObjCDVCVariable(dvcVariable:
+            return ObjCDVCVariable(
                 DVCVariable<T>(
                     key: key,
                     type: String(describing: T.self),
@@ -163,36 +163,7 @@ public class ObjCDVCClient: NSObject {
             )
         }
 
-        return ObjCDVCVariable(dvcVariable: client.variable(key: key, defaultValue: defaultValue))
-        
-//        var variable: ObjCDVCVariable
-//        if let variableFromConfig = self.client?.config?.userConfig?.variables[key] {
-//            variable = try ObjCDVCVariable(
-//                key: key,
-//                type: variableFromConfig.type,
-//                evalReason: variableFromConfig.evalReason,
-//                value: variableFromConfig.value,
-//                defaultValue: defaultValue
-//            )
-//        } else {
-//            variable = try ObjCDVCVariable(
-//                key: key,
-//                type: nil,
-//                evalReason: nil,
-//                value: nil,
-//                defaultValue: defaultValue
-//            )
-//        }
-//
-//        client?.configCompletionHandlers.append({ error in
-//            if let variableFromApi = self.client?.config?.userConfig?.variables[key] {
-//                try? variable.update(from: variableFromApi)
-//            }
-//        })
-//
-//        self.client?.updateAggregateEvents(variableKey: variable.key, variableIsDefaulted: variable.isDefaulted)
-//
-//        return variable
+        return ObjCDVCVariable(client.variable(key: key, defaultValue: defaultValue))
     }
     
     @objc public func allFeatures() -> [String: ObjCFeature]? {

--- a/DevCycle/ObjC/ObjCDVCEvent.swift
+++ b/DevCycle/ObjC/ObjCDVCEvent.swift
@@ -8,54 +8,58 @@ import Foundation
 
 @objc(DVCEvent)
 public class ObjCDVCEvent: NSObject {
-    var event: DVCEvent?
     @objc var type: String?
     @objc var target: String?
     @objc var clientDate: NSDate?
     @objc var value: NSNumber?
     @objc var metaData: NSDictionary?
 
-    init(builder: ObjCEventBuilder) throws {
-        if builder.type == nil {
+    @objc(initializeWithType:)
+    public static func initialize(type: String) -> ObjCDVCEvent {
+        return self.initialize(type: type, target: nil, value: nil)
+    }
+    
+    @objc(initializeWithType:target:)
+    public static func initialize(type: String, target: String?) -> ObjCDVCEvent {
+        return self.initialize(type: type, target: target, value: nil)
+    }
+    
+    @objc(initializeWithType:target:value:)
+    public static func initialize(type: String, target: String?, value: NSNumber?) -> ObjCDVCEvent {
+        let builder = ObjCDVCEvent()
+        builder.type = type
+        builder.target = target
+        builder.value = value
+        return builder
+    }
+    
+    func buildDVCEvent() throws -> DVCEvent {
+        if self.type == nil {
             throw ObjCEventErrors.MissingEventType
         }
         
         var eventBuilder = DVCEvent.builder()
-        if let eventType = builder.type {
+        if let eventType = self.type {
             eventBuilder = eventBuilder.type(eventType)
         }
-        if let eventTarget = builder.target {
+        if let eventTarget = self.target {
             eventBuilder = eventBuilder.target(eventTarget)
         }
-        if let eventDate = builder.clientDate {
+        if let eventDate = self.clientDate {
             eventBuilder = eventBuilder.clientDate(eventDate as Date)
         }
-        if let eventValue = builder.value {
+        if let eventValue = self.value {
             eventBuilder = eventBuilder.value(eventValue as! Int)
         }
-        if let eventMetaData = builder.metaData {
+        if let eventMetaData = self.metaData {
             eventBuilder = eventBuilder.metaData(eventMetaData as! [String : Any])
         }
-        guard let event = try? eventBuilder.build() else {
-            Log.error("Error making event", tags: ["event", "build"])
-            throw ObjCEventErrors.InvalidEvent
+        
+        do {
+            return try eventBuilder.build()
+        } catch {
+            Log.error("Error building DVCEvent: \(error)", tags: ["event", "build"])
+            throw error
         }
-        self.event = event
-    }
-    
-    @objc(DVCEventBuilder)
-    public class ObjCEventBuilder: NSObject {
-        @objc public var type: String?
-        @objc public var target: String?
-        @objc public var clientDate: NSDate?
-        @objc public var value: NSNumber?
-        @objc public var metaData: NSDictionary?
-    }
-    
-    @objc(build:block:) public static func build(_ block: ((ObjCEventBuilder) -> Void)) throws -> ObjCDVCEvent {
-        let builder = ObjCEventBuilder()
-        block(builder)
-        let event = try ObjCDVCEvent(builder: builder)
-        return event
     }
 }

--- a/DevCycle/ObjC/ObjCDVCOptions.swift
+++ b/DevCycle/ObjC/ObjCDVCOptions.swift
@@ -7,6 +7,13 @@
 
 import Foundation
 
+@objc(DVCOptionsBuilder)
+public class ObjCOptionsBuilder: NSObject {
+    @objc public var flushEventsIntervalMs: NSNumber?
+    @objc public var disableEventLogging: NSNumber?
+    @objc public var logLevel: NSNumber?
+}
+
 @objc(LogLevel)
 public class ObjCLogLevel: NSObject {
     @objc public static let debug = NSNumber(0)
@@ -17,6 +24,14 @@ public class ObjCLogLevel: NSObject {
 @objc(DVCOptions)
 public class ObjCDVCOptions: NSObject {
     var options: DVCOptions?
+    
+    @objc(build:block:)
+    public static func build(_ block: ((ObjCOptionsBuilder) -> Void)) throws -> ObjCDVCOptions {
+        let builder = ObjCOptionsBuilder()
+        block(builder)
+        let options = ObjCDVCOptions(builder: builder)
+        return options
+    }
     
     init(builder: ObjCOptionsBuilder) {
         var optionsBuilder = DVCOptions.builder()
@@ -46,19 +61,5 @@ public class ObjCDVCOptions: NSObject {
         }
         let options = optionsBuilder.build()
         self.options = options
-    }
-    
-    @objc(DVCOptionsBuilder)
-    public class ObjCOptionsBuilder: NSObject {
-        @objc public var flushEventsIntervalMs: NSNumber?
-        @objc public var disableEventLogging: NSNumber?
-        @objc public var logLevel: NSNumber?
-    }
-    
-    @objc(build:block:) public static func build(_ block: ((ObjCOptionsBuilder) -> Void)) throws -> ObjCDVCOptions {
-        let builder = ObjCOptionsBuilder()
-        block(builder)
-        let options = ObjCDVCOptions(builder: builder)
-        return options
     }
 }

--- a/DevCycle/ObjC/ObjCDVCOptions.swift
+++ b/DevCycle/ObjC/ObjCDVCOptions.swift
@@ -7,13 +7,6 @@
 
 import Foundation
 
-@objc(DVCOptionsBuilder)
-public class ObjCOptionsBuilder: NSObject {
-    @objc public var flushEventsIntervalMs: NSNumber?
-    @objc public var disableEventLogging: NSNumber?
-    @objc public var logLevel: NSNumber?
-}
-
 @objc(LogLevel)
 public class ObjCLogLevel: NSObject {
     @objc public static let debug = NSNumber(0)
@@ -22,29 +15,23 @@ public class ObjCLogLevel: NSObject {
 }
 
 @objc(DVCOptions)
-public class ObjCDVCOptions: NSObject {
-    var options: DVCOptions?
+public class ObjCOptions: NSObject {
+    @objc public var flushEventsIntervalMs: NSNumber?
+    @objc public var disableEventLogging: NSNumber?
+    @objc public var logLevel: NSNumber?
     
-    @objc(build:block:)
-    public static func build(_ block: ((ObjCOptionsBuilder) -> Void)) throws -> ObjCDVCOptions {
-        let builder = ObjCOptionsBuilder()
-        block(builder)
-        let options = ObjCDVCOptions(builder: builder)
-        return options
-    }
-    
-    init(builder: ObjCOptionsBuilder) {
+    func buildDVCOptions() -> DVCOptions {
         var optionsBuilder = DVCOptions.builder()
-        if let flushEventsIntervalMs = builder.flushEventsIntervalMs,
+        if let flushEventsIntervalMs = self.flushEventsIntervalMs,
            let interval = flushEventsIntervalMs as? Int {
             optionsBuilder = optionsBuilder.flushEventsIntervalMs(interval)
         }
         
-        if let disableEventLogging = builder.disableEventLogging,
+        if let disableEventLogging = self.disableEventLogging,
            let disable = disableEventLogging as? Bool {
             optionsBuilder = optionsBuilder.disableEventLogging(disable)
         }
-        if let logLevel = builder.logLevel,
+        if let logLevel = self.logLevel,
            let level = logLevel as? Int {
             var setLogLevel = LogLevel.error
             switch level {
@@ -59,7 +46,7 @@ public class ObjCDVCOptions: NSObject {
             }
             optionsBuilder = optionsBuilder.logLevel(setLogLevel)
         }
-        let options = optionsBuilder.build()
-        self.options = options
+        return optionsBuilder.build()
     }
 }
+

--- a/DevCycle/ObjC/ObjCDVCUser.swift
+++ b/DevCycle/ObjC/ObjCDVCUser.swift
@@ -6,6 +6,26 @@
 
 import Foundation
 
+@objc(DVCUserBuilder)
+public class ObjCUserBuilder: NSObject {
+    @objc public var userId: String?
+    @objc public var isAnonymous: NSNumber?
+    @objc public var email: String?
+    @objc public var name: String?
+    @objc public var language: String?
+    @objc public var country: String?
+    @objc public var appVersion: String?
+    @objc public var customData: [String: Any]?
+    @objc public var privateCustomData: [String: Any]?
+    
+    @objc(initializeWithUserId:)
+    public static func initialize(userId: String?) -> ObjCUserBuilder {
+        let builder = ObjCUserBuilder()
+        builder.userId = userId
+        return builder
+    }
+}
+
 @objc(DVCUser)
 public class ObjCDVCUser: NSObject {
     var user: DVCUser?
@@ -48,16 +68,20 @@ public class ObjCDVCUser: NSObject {
         }
     }
     
+    @objc(build:block:)
+    public static func build(_ block: ((ObjCUserBuilder) -> Void)) throws -> ObjCDVCUser {
+        let builder = ObjCUserBuilder()
+        block(builder)
+        let user = try ObjCDVCUser(builder: builder)
+        return user
+    }
+    
     init(builder: ObjCUserBuilder) throws {
-        if builder.userId == nil && builder.isAnonymous == false {
-            throw ObjCUserErrors.MissingUserId
-        } else if builder.userId == nil && builder.isAnonymous == nil {
-            throw ObjCUserErrors.MissingIsAnonymous
-        }
-        
         var userBuilder = DVCUser.builder()
         if let userId = builder.userId {
             userBuilder = userBuilder.userId(userId)
+        } else {
+            userBuilder = userBuilder.isAnonymous(true)
         }
         if let isAnonymous = builder.isAnonymous {
             userBuilder = userBuilder.isAnonymous(isAnonymous.boolValue)
@@ -88,25 +112,5 @@ public class ObjCDVCUser: NSObject {
             throw ObjCUserErrors.InvalidUser
         }
         self.user = user
-    }
-    
-    @objc(DVCUserBuilder)
-    public class ObjCUserBuilder: NSObject {
-        @objc public var userId: String?
-        @objc public var isAnonymous: NSNumber?
-        @objc public var email: String?
-        @objc public var name: String?
-        @objc public var language: String?
-        @objc public var country: String?
-        @objc public var appVersion: String?
-        @objc public var customData: [String: Any]?
-        @objc public var privateCustomData: [String: Any]?
-    }
-    
-    @objc(build:block:) public static func build(_ block: ((ObjCUserBuilder) -> Void)) throws -> ObjCDVCUser {
-        let builder = ObjCUserBuilder()
-        block(builder)
-        let user = try ObjCDVCUser(builder: builder)
-        return user
     }
 }

--- a/DevCycle/ObjC/ObjCDVCUser.swift
+++ b/DevCycle/ObjC/ObjCDVCUser.swift
@@ -6,8 +6,8 @@
 
 import Foundation
 
-@objc(DVCUserBuilder)
-public class ObjCUserBuilder: NSObject {
+@objc(DVCUser)
+public class ObjCUser: NSObject {
     @objc public var userId: String?
     @objc public var isAnonymous: NSNumber?
     @objc public var email: String?
@@ -19,98 +19,51 @@ public class ObjCUserBuilder: NSObject {
     @objc public var privateCustomData: [String: Any]?
     
     @objc(initializeWithUserId:)
-    public static func initialize(userId: String?) -> ObjCUserBuilder {
-        let builder = ObjCUserBuilder()
+    public static func initialize(userId: String?) -> ObjCUser {
+        let builder = ObjCUser()
         builder.userId = userId
         return builder
     }
-}
-
-@objc(DVCUser)
-public class ObjCDVCUser: NSObject {
-    var user: DVCUser?
-    @objc public var userId: String? { return user?.userId }
-    @objc public var isAnonymous: NSNumber? {
-        get {
-            if let isAnonymous = user?.isAnonymous {
-                return NSNumber(value: isAnonymous)
-            }
-            return nil
-        }
-    }
-    @objc public var email: String? { return user?.email }
-    @objc public var name: String? { return user?.name }
-    @objc public var language: String? { return user?.language }
-    @objc public var country: String? { return user?.country }
-    @objc public var appVersion: String? { return user?.appVersion }
-    @objc public var appBuild: NSNumber? {
-        guard let appBuild = user?.appBuild else { return nil }
-        return NSNumber(integerLiteral: appBuild)
-    }
-    @objc public var customData: [String:Any]? {
-        get {
-            guard let customData = user?.customData,
-                  let data = try? JSONSerialization.jsonObject(with: customData, options: []) as? [String: Any]
-            else {
-                return nil
-            }
-            return data
-        }
-    }
-    @objc public var privateCustomData: [String:Any]? {
-        get {
-            guard let privateCustomData = user?.privateCustomData,
-                  let data = try? JSONSerialization.jsonObject(with: privateCustomData, options: []) as? [String: Any]
-            else {
-                return nil
-            }
-            return data
-        }
-    }
     
-    @objc(build:block:)
-    public static func build(_ block: ((ObjCUserBuilder) -> Void)) throws -> ObjCDVCUser {
-        let builder = ObjCUserBuilder()
-        block(builder)
-        let user = try ObjCDVCUser(builder: builder)
-        return user
-    }
-    
-    init(builder: ObjCUserBuilder) throws {
+    func buildDVCUser() throws -> DVCUser {
         var userBuilder = DVCUser.builder()
-        if let userId = builder.userId {
+        if let userId = self.userId {
             userBuilder = userBuilder.userId(userId)
         } else {
             userBuilder = userBuilder.isAnonymous(true)
         }
-        if let isAnonymous = builder.isAnonymous {
+        if let isAnonymous = self.isAnonymous {
             userBuilder = userBuilder.isAnonymous(isAnonymous.boolValue)
         }
-        if let email = builder.email {
+        if let email = self.email {
             userBuilder = userBuilder.email(email)
         }
-        if let name = builder.name {
+        if let name = self.name {
             userBuilder = userBuilder.name(name)
         }
-        if let language = builder.language {
+        if let language = self.language {
             userBuilder = userBuilder.language(language)
         }
-        if let country = builder.country {
+        if let country = self.country {
             userBuilder = userBuilder.country(country)
         }
-        if let appVersion = builder.appVersion {
+        if let appVersion = self.appVersion {
             userBuilder = userBuilder.appVersion(appVersion)
         }
-        if let customData = builder.customData {
-            userBuilder = userBuilder.customData(customData)
+        if let customData = self.customData {
+            let dvcCustomData = try CustomData.customDataFromDic(customData)
+            userBuilder = userBuilder.customData(dvcCustomData)
         }
-        if let privateCustomData = builder.privateCustomData {
-            userBuilder = userBuilder.privateCustomData(privateCustomData)
+        if let privateCustomData = self.privateCustomData {
+            let dvcCustomData = try CustomData.customDataFromDic(privateCustomData)
+            userBuilder = userBuilder.privateCustomData(dvcCustomData)
         }
-        guard let user = try? userBuilder.build() else {
-            Log.error("Error making user", tags: ["user", "build"])
-            throw ObjCUserErrors.InvalidUser
+        
+        do {
+            return try userBuilder.build()
+        } catch {
+            Log.error("Error building DVCUser: \(error)", tags: ["user", "build"])
+            throw error
         }
-        self.user = user
     }
 }

--- a/DevCycle/ObjC/ObjCDVCUser.swift
+++ b/DevCycle/ObjC/ObjCDVCUser.swift
@@ -51,12 +51,10 @@ public class ObjCUser: NSObject {
             userBuilder = userBuilder.appVersion(appVersion)
         }
         if let customData = self.customData {
-            let dvcCustomData = try CustomData.customDataFromDic(customData)
-            userBuilder = userBuilder.customData(dvcCustomData)
+            userBuilder = userBuilder.customData(customData)
         }
         if let privateCustomData = self.privateCustomData {
-            let dvcCustomData = try CustomData.customDataFromDic(privateCustomData)
-            userBuilder = userBuilder.privateCustomData(dvcCustomData)
+            userBuilder = userBuilder.privateCustomData(privateCustomData)
         }
         
         do {

--- a/DevCycle/ObjC/ObjCDVCVariable.swift
+++ b/DevCycle/ObjC/ObjCDVCVariable.swift
@@ -31,7 +31,7 @@ public class ObjCDVCVariable: NSObject {
         self.defaultValue = dvcVariable.defaultValue
         super.init()
         
-        dvcVariable.onUpdate { [weak self] _ in
+        let _ = dvcVariable.onUpdate { [weak self] _ in
             if let weakSelf = self {
                 weakSelf.setValues(dvcVariable: dvcVariable)
                 weakSelf.handler?(weakSelf)

--- a/DevCycle/ObjC/ObjCDVCVariable.swift
+++ b/DevCycle/ObjC/ObjCDVCVariable.swift
@@ -21,26 +21,38 @@ public class ObjCDVCVariable: NSObject {
     @objc public var value: Any
     @objc public var defaultValue: Any
     
-    @objc public init (key: String, type: String?, evalReason: String?, value: Any?, defaultValue: Any) throws {
-        if (value != nil && Swift.type(of: defaultValue) != Swift.type(of: value!)) {
-            throw ObjCVariableError.VariableValueDoesntMatchDefaultValueType("For variable: \(key)")
-        }
-        self.key = key
-        self.type = type
-        self.evalReason = evalReason
-        self.defaultValue = defaultValue
-        self.value = value ?? defaultValue
-        self.isDefaulted = value == nil
+    
+    init<T>(dvcVariable: DVCVariable<T>) {
+        self.key = dvcVariable.key
+        self.type = dvcVariable.type
+        self.evalReason = dvcVariable.evalReason
+        self.isDefaulted = dvcVariable.isDefaulted
+        self.value = dvcVariable.value
+        self.defaultValue = dvcVariable.defaultValue
+        
+        //TODO handle updates
     }
     
-    func update(from variable: Variable) throws {
-        guard Swift.type(of: self.defaultValue) != Swift.type(of: variable.value) else {
-            Log.error("Variable value of type \(Swift.type(of: variable.value)) doesn't match default value type: \(self.defaultValue)", tags: ["variable", "objc"])
-            return
-        }
-        self.value = variable.value
-        self.type = variable.type
-        self.evalReason = variable.evalReason
-        self.isDefaulted = false
-    }
+//    @objc public init (key: String, type: String?, evalReason: String?, value: Any?, defaultValue: Any) throws {
+//        if (value != nil && Swift.type(of: defaultValue) != Swift.type(of: value!)) {
+//            throw ObjCVariableError.VariableValueDoesntMatchDefaultValueType("For variable: \(key)")
+//        }
+//        self.key = key
+//        self.type = type
+//        self.evalReason = evalReason
+//        self.defaultValue = defaultValue
+//        self.value = value ?? defaultValue
+//        self.isDefaulted = value == nil
+//    }
+    
+//    func update(from variable: Variable) throws {
+//        guard Swift.type(of: self.defaultValue) != Swift.type(of: variable.value) else {
+//            Log.error("Variable value of type \(Swift.type(of: variable.value)) doesn't match default value type: \(self.defaultValue)", tags: ["variable", "objc"])
+//            return
+//        }
+//        self.value = variable.value
+//        self.type = variable.type
+//        self.evalReason = variable.evalReason
+//        self.isDefaulted = false
+//    }
 }

--- a/DevCycle/ObjC/ObjCUserConfig.swift
+++ b/DevCycle/ObjC/ObjCUserConfig.swift
@@ -14,23 +14,11 @@ public class ObjCFeature: NSObject {
     private(set) var key: String
     private(set) var type: String
     
-    @objc init(id: String,
-                  variation: String,
-                  key: String,
-                  type: String) {
-        self._id = id
-        self._variation = variation
-        self.key = key
-        self.type = type
-    }
-    
-    static func create(from feature: Feature) -> ObjCFeature {
-        return ObjCFeature(
-            id: feature._id,
-            variation: feature._variation,
-            key: feature.key,
-            type: feature.type
-        )
+    init(_ feature: Feature) {
+        self._id = feature._id
+        self._variation = feature._variation
+        self.key = feature.key
+        self.type = feature.type
     }
     
     override public var description: String {
@@ -47,26 +35,12 @@ public class ObjCVariable: NSObject {
     private(set) var value: Any
     private(set) var evalReason: String?
     
-    @objc init(id: String,
-                  key: String,
-                  type: String,
-                  value: Any,
-                  evalReason: String?) {
-        self._id = id
-        self.key = key
-        self.type = type
-        self.value = value
-        self.evalReason = evalReason
-    }
-    
-    static func create(from variable: Variable) -> ObjCVariable {
-        return ObjCVariable(
-            id: variable._id,
-            key: variable.key,
-            type: variable.type,
-            value: variable.value,
-            evalReason: variable.evalReason
-        )
+    init(_ variable: Variable) {
+        self._id = variable._id
+        self.key = variable.key
+        self.type = variable.type
+        self.value = variable.value
+        self.evalReason = variable.evalReason
     }
     
     override public var description: String {

--- a/DevCycleTests/ObjC/ObjCDVCClientTests.m
+++ b/DevCycleTests/ObjC/ObjCDVCClientTests.m
@@ -14,57 +14,43 @@
 @implementation ObjcDVCClientTests
 
 - (void)testBuilderReturnsErrorIfNoEnvKey {
-    NSError *err = nil;
-    DVCUser *user = [DVCUser build:&err block:^(DVCUserBuilder *builder) {
-        builder.userId = @"my_user";
+    DVCUser *user = [DVCUser initializeWithUserId:@"my_user"];
+    DVCClient *client = [DVCClient initialize:nil user:user options:nil onInitialized:^(NSError * _Nullable err) {
+        XCTAssertNil(client);
+        XCTAssertNotNil(err);
     }];
-    
-    DVCClient *client = [DVCClient build:&err block:^(DVCClientBuilder *builder) {
-        builder.user = user;
-    } onInitialized: nil];
-    XCTAssertNil(client);
-    XCTAssertNotNil(err);
 }
 
 - (void)testBuilderReturnsErrorIfNoUser {
-    NSError *err = nil;
-    DVCClient *client = [DVCClient build:&err block:^(DVCClientBuilder *builder) {
-        builder.environmentKey = @"my_env_key";
-    } onInitialized: nil];
-    XCTAssertNil(client);
-    XCTAssertNotNil(err);
+    DVCClient *client = [DVCClient initialize:@"my_env_key" user:nil options:nil onInitialized:^(NSError * _Nullable err) {
+        XCTAssertNil(client);
+        XCTAssertNotNil(err);
+    }];
 }
 
 - (void)testBuilderCreatesClientWithUserAndEnvKey {
-    NSError *err = nil;
-    DVCUser *user = [DVCUser build:&err block:^(DVCUserBuilder *builder) {
-        builder.userId = @"my_user";
+    DVCUser *user = [DVCUser initializeWithUserId:@"my_user"];
+    DVCClient *client = [DVCClient initialize:@"my_env_key" user:user options:nil onInitialized:^(NSError * _Nullable err) {
+        XCTAssertNil(err);
+        XCTAssertNotNil(client);
     }];
-    DVCClient *client = [DVCClient build:&err block:^(DVCClientBuilder *builder) {
-        builder.environmentKey = @"my_env_key";
-        builder.user = user;
-    } onInitialized: nil];
-    XCTAssertNil(err);
-    XCTAssertNotNil(client);
 }
 
 #pragma mark - Variable Tests
 
 - (void)testVariableIsCreated {
-    NSError *err = nil;
-    DVCUser *user = [DVCUser build:&err block:^(DVCUserBuilder *builder) {
-        builder.userId = @"my_user";
+    DVCUser *user = [DVCUser initializeWithUserId:@"my_user"];
+    DVCClient *client = [DVCClient initialize:@"my_env_key" user:user options:nil onInitialized:^(NSError * _Nullable err) {
+        XCTAssertNil(err);
+        XCTAssertNotNil(client);
+        
+        DVCVariable *variable = [client stringVariableWithKey:@"my-key" defaultValue:@"default-value"];
+        XCTAssertNotNil(variable);
+        XCTAssertNil(variable.type);
+        XCTAssertNil(variable.evalReason);
+        XCTAssertEqual(variable.value, @"default-value");
+        XCTAssertEqual(variable.defaultValue, @"default-value");
     }];
-    DVCClient *client = [DVCClient build:&err block:^(DVCClientBuilder *builder) {
-        builder.environmentKey = @"my_env_key";
-        builder.user = user;
-    } onInitialized:nil];
-    DVCVariable *variable = [client variableWithKey:@"my-key" defaultValue:@"default-value" error:&err];
-    XCTAssertNotNil(variable);
-    XCTAssertNil(variable.type);
-    XCTAssertNil(variable.evalReason);
-    XCTAssertEqual(variable.value, @"default-value");
-    XCTAssertEqual(variable.defaultValue, @"default-value");
 }
 
 @end

--- a/DevCycleTests/ObjC/ObjcDVCUserTests.m
+++ b/DevCycleTests/ObjC/ObjcDVCUserTests.m
@@ -14,64 +14,53 @@
 @implementation ObjcDVCUserTests
 
 - (void)testCreateUser {
-    NSError *err = nil;
-    DVCUser *user = [DVCUser build:&err block:^(DVCUserBuilder *builder) {
-        builder.userId = @"my_user";
+    DVCUser *user = [DVCUser initializeWithUserId:@"my_user"];
+    DVCClient *client = [DVCClient initialize:@"my_env_key" user:user options:nil onInitialized:^(NSError * _Nullable err) {
+        XCTAssertNil(err);
     }];
-    XCTAssertNotNil(user);
-    XCTAssertNil(err);
 }
 
-- (void)testReturnsErrorIfNoUserIdOrIsAnonymousSet {
-    NSError *err = nil;
-    DVCUser *user = [DVCUser build:&err block:^(DVCUserBuilder *builder) {}];
-    XCTAssertNil(user);
-    XCTAssertNotNil(err);
-}
-
-- (void)testReturnsErrorIfNoUserIdOrIsAnonymousSetToFalse {
-    NSError *err = nil;
-    DVCUser *user = [DVCUser build:&err block:^(DVCUserBuilder *builder) {
-        builder.isAnonymous = @NO;
+- (void)testAnonUser {
+    DVCUser *user = [[DVCUser alloc] init];
+    DVCClient *client = [DVCClient initialize:@"my_env_key" user:user options:nil onInitialized:^(NSError * _Nullable err) {
+        XCTAssertNil(err);
+        XCTAssertTrue(user.isAnonymous);
     }];
-    XCTAssertNil(user);
-    XCTAssertNotNil(err);
 }
-
 
 - (void)testNonUserIdPropertiesAreNil {
-    NSError *err = nil;
-    DVCUser *user = [DVCUser build:&err block:^(DVCUserBuilder *builder) {
-        builder.userId = @"my_user";
+    DVCUser *user = [DVCUser initializeWithUserId:@"my_user"];
+    DVCClient *client = [DVCClient initialize:@"my_env_key" user:user options:nil onInitialized:^(NSError * _Nullable err) {
+        XCTAssertNil(err);
+        XCTAssertNotNil(user);
+        XCTAssert([user.userId isEqual:@"my_user"]);
+        XCTAssertFalse([user.isAnonymous boolValue]);
+        XCTAssertNil(user.email);
+        XCTAssertNil(user.name);
+        XCTAssertNil(user.country);
+        XCTAssertNil(user.appVersion);
+        XCTAssertNil(user.customData);
+        XCTAssertNil(user.privateCustomData);
     }];
-    XCTAssertNotNil(user);
-    XCTAssert([user.userId isEqual:@"my_user"]);
-    XCTAssertFalse([user.isAnonymous boolValue]);
-    XCTAssertNil(user.email);
-    XCTAssertNil(user.name);
-    XCTAssertNil(user.country);
-    XCTAssertNil(user.appVersion);
-    XCTAssertNil(user.customData);
-    XCTAssertNil(user.privateCustomData);
 }
 
 - (void)testNonUserIdPropertiesAreNotNil {
-    NSError *err = nil;
-    DVCUser *user = [DVCUser build:&err block:^(DVCUserBuilder *builder) {
-        builder.userId = @"my_user";
-        builder.isAnonymous = @NO;
-        builder.email = @"email.com";
-        builder.name = @"Jason Smith";
-        builder.country = @"CAN";
-        builder.appVersion = @"1.0.0";
+    DVCUser *user = [DVCUser initializeWithUserId:@"my_user"];
+    user.isAnonymous = @NO;
+    user.email = @"email.com";
+    user.name = @"Jason Smith";
+    user.country = @"CAN";
+    user.appVersion = @"1.0.0";
+    DVCClient *client = [DVCClient initialize:@"my_env_key" user:user options:nil onInitialized:^(NSError * _Nullable err) {
+        XCTAssertNil(err);
+        XCTAssertNotNil(user);
+        XCTAssert([user.userId isEqual:@"my_user"]);
+        XCTAssertFalse([user.isAnonymous boolValue]);
+        XCTAssertEqual(user.email, @"email.com");
+        XCTAssertEqual(user.name, @"Jason Smith");
+        XCTAssertEqual(user.country, @"CAN");
+        XCTAssertEqual(user.appVersion, @"1.0.0");
     }];
-    XCTAssertNotNil(user);
-    XCTAssert([user.userId isEqual:@"my_user"]);
-    XCTAssertFalse([user.isAnonymous boolValue]);
-    XCTAssertEqual(user.email, @"email.com");
-    XCTAssertEqual(user.name, @"Jason Smith");
-    XCTAssertEqual(user.country, @"CAN");
-    XCTAssertEqual(user.appVersion, @"1.0.0");
 }
 
 @end

--- a/DevCycleTests/ObjC/ObjcDVCVariableTests.m
+++ b/DevCycleTests/ObjC/ObjcDVCVariableTests.m
@@ -15,11 +15,9 @@
 @implementation ObjcDVCVariableTests
 
 - (void)testVariableGetsCreatedWithDefault {
-    NSError *err = nil;
     DVCUser *user = [DVCUser initializeWithUserId:@"my_user"];
-    DVCClient *client = [DVCClient initialize:@"key" user:user err:&err];
+    DVCClient *client = [DVCClient initialize:@"key" user:user];
     DVCVariable *variable = [client stringVariableWithKey:@"my-key" defaultValue:@"my-default"];
-    XCTAssertNil(err);
     XCTAssertNotNil(variable);
     XCTAssertEqual(variable.value, @"my-default");
     XCTAssertEqual(variable.defaultValue, @"my-default");

--- a/DevCycleTests/ObjC/ObjcDVCVariableTests.m
+++ b/DevCycleTests/ObjC/ObjcDVCVariableTests.m
@@ -14,21 +14,16 @@
 
 @implementation ObjcDVCVariableTests
 
-- (void)testVariableGetsCreated {
+- (void)testVariableGetsCreatedWithDefault {
     NSError *err = nil;
-    DVCVariable *variable = [[DVCVariable alloc] initWithKey:@"my-key" type:@"String" evalReason:nil value:@"my-value" defaultValue:@"my-default" error:&err];
+    DVCUser *user = [DVCUser initializeWithUserId:@"my_user"];
+    DVCClient *client = [DVCClient initialize:@"key" user:user err:&err];
+    DVCVariable *variable = [client stringVariableWithKey:@"my-key" defaultValue:@"my-default"];
     XCTAssertNil(err);
     XCTAssertNotNil(variable);
-    XCTAssertEqual(variable.value, @"my-value");
+    XCTAssertEqual(variable.value, @"my-default");
     XCTAssertEqual(variable.defaultValue, @"my-default");
     XCTAssertNil(variable.evalReason);
-}
-
-- (void)testVariableThrowsErrorIfValueTypeDoesntMatchDefault {
-    NSError *err = nil;
-    DVCVariable *variable = [[DVCVariable alloc] initWithKey:@"my-key" type:@"String" evalReason:nil value:@5 defaultValue:@"my-default" error:&err];
-    XCTAssertNotNil(err);
-    XCTAssertNil(variable);
 }
 
 @end

--- a/Examples/DevCycle-Example-App-ObjC/DevCycle-Example-App-ObjC/AppDelegate.m
+++ b/Examples/DevCycle-Example-App-ObjC/DevCycle-Example-App-ObjC/AppDelegate.m
@@ -18,16 +18,25 @@
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
     // Builder
-    NSError *err = nil;
-    DVCUser *user = [DVCUser build:&err block:^(DVCUserBuilder *builder) {
-        builder.userId = @"test_user";
-    }];
-    [[DevCycleManager sharedManager] initialize:user];
+//    NSError *err = nil;
+//    DVCUser *user = [DVCUser build:&err block:^(DVCUserBuilder *builder) {
+//        builder.userId = @"test_user";
+//    }];
+//    [[DevCycleManager sharedManager] initialize:user];
 //    [[DevCycleManager sharedManager].client variableWithKey:@"key" defaultValue:@"default" error:&err];
     
     // Init
     DVCUserBuilder *userBuilder = [DVCUserBuilder initializeWithUserId:@"test_user"];
-    [[DevCycleManager sharedManager] initializeUserBuilder:userBuilder];
+    userBuilder.customData = @{@"key": @"value"};
+    DVCClient *client = [[DevCycleManager sharedManager] initializeUserBuilder:userBuilder];
+    
+
+    DVCVariable *stringVar = [client stringVariableWithKey:@"string_key" defaultValue:@"default"];
+    DVCVariable *numVar = [client numberVariableWithKey:@"num_key" defaultValue:@610];
+    DVCVariable *boolVar = [client boolVariableWithKey:@"bool_key" defaultValue:true];
+    DVCVariable *jsonVar = [client jsonVariableWithKey:@"json_key" defaultValue:@{@"key": @"value"}];
+    
+    NSLog(@"DVC Var Values\nstring: %@\n num: %@\n bool: %@\njson: %@", stringVar, numVar, boolVar, jsonVar); 
     
     return YES;
 }

--- a/Examples/DevCycle-Example-App-ObjC/DevCycle-Example-App-ObjC/AppDelegate.m
+++ b/Examples/DevCycle-Example-App-ObjC/DevCycle-Example-App-ObjC/AppDelegate.m
@@ -17,11 +17,18 @@
 
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+    // Builder
     NSError *err = nil;
     DVCUser *user = [DVCUser build:&err block:^(DVCUserBuilder *builder) {
-        builder.isAnonymous = @YES;
+        builder.userId = @"test_user";
     }];
     [[DevCycleManager sharedManager] initialize:user];
+//    [[DevCycleManager sharedManager].client variableWithKey:@"key" defaultValue:@"default" error:&err];
+    
+    // Init
+    DVCUserBuilder *userBuilder = [DVCUserBuilder initializeWithUserId:@"test_user"];
+    [[DevCycleManager sharedManager] initializeUserBuilder:userBuilder];
+    
     return YES;
 }
 

--- a/Examples/DevCycle-Example-App-ObjC/DevCycle-Example-App-ObjC/AppDelegate.m
+++ b/Examples/DevCycle-Example-App-ObjC/DevCycle-Example-App-ObjC/AppDelegate.m
@@ -31,12 +31,24 @@
     DVCClient *client = [[DevCycleManager sharedManager] initializeUserBuilder:userBuilder];
     
 
-    DVCVariable *stringVar = [client stringVariableWithKey:@"string_key" defaultValue:@"default"];
-    DVCVariable *numVar = [client numberVariableWithKey:@"num_key" defaultValue:@610];
-    DVCVariable *boolVar = [client boolVariableWithKey:@"bool_key" defaultValue:true];
-    DVCVariable *jsonVar = [client jsonVariableWithKey:@"json_key" defaultValue:@{@"key": @"value"}];
+    DVCVariable *stringVar = [[client stringVariableWithKey:@"string_key" defaultValue:@"default"]
+                              onUpdateWithHandler:^(id _Nonnull value) {
+        NSLog(@"string_key value updated: %@", value);
+    }];
+    DVCVariable *numVar = [[client numberVariableWithKey:@"num_key" defaultValue:@610]
+                           onUpdateWithHandler:^(id _Nonnull value) {
+        NSLog(@"num_key value updated: %@", value);
+    }];
+    DVCVariable *boolVar = [[client boolVariableWithKey:@"bool_key" defaultValue:true]
+                            onUpdateWithHandler:^(id _Nonnull value) {
+        NSLog(@"bool_key value updated: %@", value);
+    }];
+    DVCVariable *jsonVar = [[client jsonVariableWithKey:@"json_key" defaultValue:@{@"key": @"value"}]
+                            onUpdateWithHandler:^(id _Nonnull value) {
+        NSLog(@"json_key value updated: %@", value);
+    }];
     
-    NSLog(@"DVC Var Values\nstring: %@\n num: %@\n bool: %@\njson: %@", stringVar, numVar, boolVar, jsonVar); 
+    NSLog(@"DVC Var Values\nstring: %@\n num: %@\n bool: %@\njson: %@", stringVar, numVar, boolVar, jsonVar);
     
     return YES;
 }

--- a/Examples/DevCycle-Example-App-ObjC/DevCycle-Example-App-ObjC/AppDelegate.m
+++ b/Examples/DevCycle-Example-App-ObjC/DevCycle-Example-App-ObjC/AppDelegate.m
@@ -17,38 +17,43 @@
 
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
-    // Builder
-//    NSError *err = nil;
-//    DVCUser *user = [DVCUser build:&err block:^(DVCUserBuilder *builder) {
-//        builder.userId = @"test_user";
-//    }];
-//    [[DevCycleManager sharedManager] initialize:user];
-//    [[DevCycleManager sharedManager].client variableWithKey:@"key" defaultValue:@"default" error:&err];
+    DVCUser *user = [DVCUser initializeWithUserId:@"test_user"];
+    user.customData = @{
+        @"key": @"value",
+        @"num": @610.610,
+        @"bool": @YES
+    };
     
-    // Init
-    DVCUserBuilder *userBuilder = [DVCUserBuilder initializeWithUserId:@"test_user"];
-    userBuilder.customData = @{@"key": @"value"};
-    DVCClient *client = [[DevCycleManager sharedManager] initializeUserBuilder:userBuilder];
-    
-
-    DVCVariable *stringVar = [[client stringVariableWithKey:@"string_key" defaultValue:@"default"]
-                              onUpdateWithHandler:^(id _Nonnull value) {
-        NSLog(@"string_key value updated: %@", value);
+    [[DevCycleManager sharedManager] initialize:user onInitialized:^(NSError * _Nonnull err) {
+        DVCClient *client = [[DevCycleManager sharedManager] client];
+        if (err || client == nil) {
+            return NSLog(@"Error starting DevCycle: %@", err.description);
+        }
+        
+        DVCVariable *stringVar = [[client stringVariableWithKey:@"string_key" defaultValue:@"default"]
+                                  onUpdateWithHandler:^(id _Nonnull value) {
+            NSLog(@"string_key value updated: %@", value);
+        }];
+        DVCVariable *numVar = [[client numberVariableWithKey:@"num_key" defaultValue:@610]
+                               onUpdateWithHandler:^(id _Nonnull value) {
+            NSLog(@"num_key value updated: %@", value);
+        }];
+        DVCVariable *boolVar = [[client boolVariableWithKey:@"bool_key" defaultValue:true]
+                                onUpdateWithHandler:^(id _Nonnull value) {
+            NSLog(@"bool_key value updated: %@", value);
+        }];
+        DVCVariable *jsonVar = [[client jsonVariableWithKey:@"json_key" defaultValue:@{@"key": @"value"}]
+                                onUpdateWithHandler:^(id _Nonnull value) {
+            NSLog(@"json_key value updated: %@", value);
+        }];
+        
+        NSLog(@"DVC Var Values\n string: %@\n num: %@\n bool: %@\n json: %@", stringVar.value, numVar.value, boolVar.value, jsonVar.value);
+        
+        NSDictionary *allFeatures = [client allFeatures];
+        NSLog(@"DVC All Features: %@", allFeatures);
+        NSDictionary *allVariables = [client allVariables];
+        NSLog(@"DVC All Variables: %@", allVariables);
     }];
-    DVCVariable *numVar = [[client numberVariableWithKey:@"num_key" defaultValue:@610]
-                           onUpdateWithHandler:^(id _Nonnull value) {
-        NSLog(@"num_key value updated: %@", value);
-    }];
-    DVCVariable *boolVar = [[client boolVariableWithKey:@"bool_key" defaultValue:true]
-                            onUpdateWithHandler:^(id _Nonnull value) {
-        NSLog(@"bool_key value updated: %@", value);
-    }];
-    DVCVariable *jsonVar = [[client jsonVariableWithKey:@"json_key" defaultValue:@{@"key": @"value"}]
-                            onUpdateWithHandler:^(id _Nonnull value) {
-        NSLog(@"json_key value updated: %@", value);
-    }];
-    
-    NSLog(@"DVC Var Values\nstring: %@\n num: %@\n bool: %@\njson: %@", stringVar, numVar, boolVar, jsonVar);
     
     return YES;
 }

--- a/Examples/DevCycle-Example-App-ObjC/DevCycle-Example-App-ObjC/Managers/DevCycleManager.h
+++ b/Examples/DevCycle-Example-App-ObjC/DevCycle-Example-App-ObjC/Managers/DevCycleManager.h
@@ -15,7 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (id)sharedManager;
 - (void)initialize:(DVCUser *)user;
-- (void)initializeUserBuilder:(DVCUserBuilder *)userBuilder;
+- (DVCClient*)initializeUserBuilder:(DVCUserBuilder *)userBuilder;
 
 @end
 

--- a/Examples/DevCycle-Example-App-ObjC/DevCycle-Example-App-ObjC/Managers/DevCycleManager.h
+++ b/Examples/DevCycle-Example-App-ObjC/DevCycle-Example-App-ObjC/Managers/DevCycleManager.h
@@ -11,11 +11,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface DevCycleManager : NSObject
 
-@property DVCClient * _Nullable client;
+@property (atomic, readonly) DVCClient * _Nullable client;
 
 + (id)sharedManager;
-- (void)initialize:(DVCUser *)user;
-- (DVCClient*)initializeUserBuilder:(DVCUserBuilder *)userBuilder;
+- (DVCClient*)initialize:(DVCUser *)user onInitialized:(void (^_Nullable)(NSError*))onInitialized;
 
 @end
 

--- a/Examples/DevCycle-Example-App-ObjC/DevCycle-Example-App-ObjC/Managers/DevCycleManager.h
+++ b/Examples/DevCycle-Example-App-ObjC/DevCycle-Example-App-ObjC/Managers/DevCycleManager.h
@@ -15,6 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (id)sharedManager;
 - (void)initialize:(DVCUser *)user;
+- (void)initializeUserBuilder:(DVCUserBuilder *)userBuilder;
 
 @end
 

--- a/Examples/DevCycle-Example-App-ObjC/DevCycle-Example-App-ObjC/Managers/DevCycleManager.m
+++ b/Examples/DevCycle-Example-App-ObjC/DevCycle-Example-App-ObjC/Managers/DevCycleManager.m
@@ -39,5 +39,17 @@ static NSString *const DEVELOPMENT_KEY = @"mobile-16e8e500-80d2-4bb5-9d4f-821938
     } onInitialized:nil];
 }
 
+- (void)initializeUserBuilder:(DVCUserBuilder *)userBuilder {
+    NSError *err = nil;
+    
+    DVCOptionsBuilder *optionsBuilder = [DVCOptionsBuilder init];
+    optionsBuilder.logLevel = LogLevel.debug;
+    
+    self.client = [DVCClient initialize:DEVELOPMENT_KEY
+                                   user:userBuilder
+                                options:optionsBuilder
+                                    err:&err];
+}
+
 
 @end

--- a/Examples/DevCycle-Example-App-ObjC/DevCycle-Example-App-ObjC/Managers/DevCycleManager.m
+++ b/Examples/DevCycle-Example-App-ObjC/DevCycle-Example-App-ObjC/Managers/DevCycleManager.m
@@ -39,7 +39,7 @@ static NSString *const DEVELOPMENT_KEY = @"mobile-16e8e500-80d2-4bb5-9d4f-821938
     } onInitialized:nil];
 }
 
-- (void)initializeUserBuilder:(DVCUserBuilder *)userBuilder {
+- (DVCClient*)initializeUserBuilder:(DVCUserBuilder *)userBuilder {
     NSError *err = nil;
     
     DVCOptionsBuilder *optionsBuilder = [DVCOptionsBuilder init];
@@ -49,6 +49,8 @@ static NSString *const DEVELOPMENT_KEY = @"mobile-16e8e500-80d2-4bb5-9d4f-821938
                                    user:userBuilder
                                 options:optionsBuilder
                                     err:&err];
+    
+    return self.client;
 }
 
 

--- a/Examples/DevCycle-Example-App-ObjC/DevCycle-Example-App-ObjC/Managers/DevCycleManager.m
+++ b/Examples/DevCycle-Example-App-ObjC/DevCycle-Example-App-ObjC/Managers/DevCycleManager.m
@@ -7,6 +7,12 @@
 #import "DevCycleManager.h"
 @import DevCycle;
 
+@interface DevCycleManager()
+
+@property (atomic) DVCClient * _Nullable client;
+
+@end
+
 @implementation DevCycleManager
 
 static NSString *const DEVELOPMENT_KEY = @"mobile-16e8e500-80d2-4bb5-9d4f-8219381a90da";
@@ -27,31 +33,22 @@ static NSString *const DEVELOPMENT_KEY = @"mobile-16e8e500-80d2-4bb5-9d4f-821938
   return self;
 }
 
-- (void)initialize:(DVCUser *)user {
-    NSError *err = nil;
-    DVCOptions *options = [DVCOptions build:&err block:^(DVCOptionsBuilder *builder) {
-        builder.logLevel = LogLevel.debug;
-    }];
-    self.client = [DVCClient build:&err block:^(DVCClientBuilder *builder) {
-        builder.user = user;
-        builder.environmentKey = DEVELOPMENT_KEY;
-        builder.options = options;
-    } onInitialized:nil];
-}
-
-- (DVCClient*)initializeUserBuilder:(DVCUserBuilder *)userBuilder {
+- (DVCClient*)initialize:(DVCUser *)user onInitialized:(void (^_Nullable)(NSError*))onInitialized {
     NSError *err = nil;
     
-    DVCOptionsBuilder *optionsBuilder = [DVCOptionsBuilder init];
-    optionsBuilder.logLevel = LogLevel.debug;
+    DVCOptions *options = [[DVCOptions alloc] init];
+    options.logLevel = LogLevel.debug;
     
     self.client = [DVCClient initialize:DEVELOPMENT_KEY
-                                   user:userBuilder
-                                options:optionsBuilder
-                                    err:&err];
+                                   user:user
+                                options:options
+                                    err:&err
+                          onInitialized:onInitialized];
+    if (err) {
+        NSLog(@"Error Starting DevCycle: %@", err);
+    }
     
     return self.client;
 }
-
 
 @end

--- a/Examples/DevCycle-Example-App-ObjC/DevCycle-Example-App-ObjC/Managers/DevCycleManager.m
+++ b/Examples/DevCycle-Example-App-ObjC/DevCycle-Example-App-ObjC/Managers/DevCycleManager.m
@@ -37,12 +37,11 @@ static NSString *const DEVELOPMENT_KEY = @"mobile-16e8e500-80d2-4bb5-9d4f-821938
     NSError *err = nil;
     
     DVCOptions *options = [[DVCOptions alloc] init];
-    options.logLevel = LogLevel.debug;
+//    options.logLevel = LogLevel.debug;
     
     self.client = [DVCClient initialize:DEVELOPMENT_KEY
                                    user:user
                                 options:options
-                                    err:&err
                           onInitialized:onInitialized];
     if (err) {
         NSLog(@"Error Starting DevCycle: %@", err);

--- a/Examples/DevCycle-Example-App-ObjC/DevCycle-Example-App-ObjC/ViewController.m
+++ b/Examples/DevCycle-Example-App-ObjC/DevCycle-Example-App-ObjC/ViewController.m
@@ -19,7 +19,6 @@
 @implementation ViewController
 
 - (IBAction)loginButtonPressed:(id)sender {
-    NSError *err = nil;
     __weak typeof(self) weakSelf = self;
     if (self.loggedIn) {
         [self.client resetUser:^(NSError *error, NSDictionary<NSString *,id> *variables) {
@@ -28,7 +27,6 @@
             weakSelf.loggedIn = NO;
         }];
     } else {
-        // TODO:
         DVCUser *user = [DVCUser initializeWithUserId:@"my-user"];
         user.userId = @"my-user";
         user.name = @"My Name";
@@ -37,7 +35,10 @@
         user.country = @"CA";
         user.email = @"my@email.com";
         
-        [self.client identifyUser:user err:&err callback:^(NSError *error, NSDictionary<NSString *,id> *variables) {
+        [self.client identifyUser:user callback:^(NSError *error, NSDictionary<NSString *,id> *variables) {
+            if (error) {
+                return NSLog(@"Error calling DVCClient identifyUser:callback: %@", error);
+            }
             NSLog(@"Identified User!");
             NSLog(@"%@", variables);
             weakSelf.loggedIn = YES;
@@ -47,11 +48,11 @@
 
 - (IBAction)track:(id)sender {
     NSError *err = nil;
-    DVCEvent *event = [DVCEvent build:&err block:^(DVCEventBuilder *builder) {
-        builder.type = @"my-event";
-        builder.clientDate = [NSDate date];
-    }];
-    [self.client track:event];
+    DVCEvent *event = [DVCEvent initializeWithType:@"my-event"];
+    [self.client track:event err:&err];
+    if (err) {
+        NSLog(@"Error calling DVCClient track:err: %@", err);
+    }
 }
 
 

--- a/Examples/DevCycle-Example-App-ObjC/DevCycle-Example-App-ObjC/ViewController.m
+++ b/Examples/DevCycle-Example-App-ObjC/DevCycle-Example-App-ObjC/ViewController.m
@@ -28,15 +28,16 @@
             weakSelf.loggedIn = NO;
         }];
     } else {
-        DVCUser *user = [DVCUser build:&err block:^(DVCUserBuilder * builder) {
-            builder.userId = @"my-user";
-            builder.name = @"My Name";
-            builder.language = @"EN-CA";
-            builder.appVersion = @"1.0.0";
-            builder.country = @"CA";
-            builder.email = @"my@email.com";
-        }];
-        [self.client identifyUser:user user:^(NSError *error, NSDictionary<NSString *,id> *variables) {
+        // TODO:
+        DVCUser *user = [DVCUser initializeWithUserId:@"my-user"];
+        user.userId = @"my-user";
+        user.name = @"My Name";
+        user.language = @"EN-CA";
+        user.appVersion = @"1.0.0";
+        user.country = @"CA";
+        user.email = @"my@email.com";
+        
+        [self.client identifyUser:user err:&err callback:^(NSError *error, NSDictionary<NSString *,id> *variables) {
             NSLog(@"Identified User!");
             NSLog(@"%@", variables);
             weakSelf.loggedIn = YES;


### PR DESCRIPTION
Made changes to the builder pattern where all the builder values are evaluated by the `initialize:` method not before being passed into the `initialize:` method. This allows for only one `err` response that needs to be checked. Kept the existing interface in-place for now, we can clean this all up a bunch once we decide on which way to go.