### PR TITLE
feat: Flush Callback

### DIFF
--- a/DevCycle-iOS.xcodeproj/project.pbxproj
+++ b/DevCycle-iOS.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		5276C9F2275E6E0D00B9A324 /* DVCOptionsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5276C9F1275E6E0D00B9A324 /* DVCOptionsTest.swift */; };
 		529F0C90277374150075AAB4 /* ObjcDVCVariableTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 529F0C8F277374150075AAB4 /* ObjcDVCVariableTests.m */; };
 		529F0CA52774D6BE0075AAB4 /* URLSessionMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 529F0CA42774D6BE0075AAB4 /* URLSessionMock.swift */; };
+		52A1139F27AB235C000B8285 /* EventQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52A1139E27AB235C000B8285 /* EventQueueTests.swift */; };
 		52A486762784A3E600DABA34 /* ObjCDVCOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52A486752784A3E600DABA34 /* ObjCDVCOptions.swift */; };
 		52A487032788C0FF00DABA34 /* ObjCUserConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52A487022788C0FF00DABA34 /* ObjCUserConfig.swift */; };
 		52A48707278C9BE200DABA34 /* Log.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52A48706278C9BE200DABA34 /* Log.swift */; };
@@ -78,6 +79,7 @@
 		5276C9F1275E6E0D00B9A324 /* DVCOptionsTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DVCOptionsTest.swift; sourceTree = "<group>"; };
 		529F0C8F277374150075AAB4 /* ObjcDVCVariableTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ObjcDVCVariableTests.m; sourceTree = "<group>"; };
 		529F0CA42774D6BE0075AAB4 /* URLSessionMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionMock.swift; sourceTree = "<group>"; };
+		52A1139E27AB235C000B8285 /* EventQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventQueueTests.swift; sourceTree = "<group>"; };
 		52A486752784A3E600DABA34 /* ObjCDVCOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjCDVCOptions.swift; sourceTree = "<group>"; };
 		52A487022788C0FF00DABA34 /* ObjCUserConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjCUserConfig.swift; sourceTree = "<group>"; };
 		52A48706278C9BE200DABA34 /* Log.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Log.swift; sourceTree = "<group>"; };
@@ -168,6 +170,7 @@
 		5268DB5A27501CFC00D17A40 /* DevCycleTests */ = {
 			isa = PBXGroup;
 			children = (
+				52A1139E27AB235C000B8285 /* EventQueueTests.swift */,
 				529F0CA32774D6A70075AAB4 /* Mocks */,
 				529F0C8E277373D10075AAB4 /* ObjC */,
 				5264A78C2768E87C00FEDB43 /* Models */,
@@ -368,6 +371,7 @@
 				5268DB6B275020F800D17A40 /* DVCClientTest.swift in Sources */,
 				529F0C90277374150075AAB4 /* ObjcDVCVariableTests.m in Sources */,
 				5268DB69275020D900D17A40 /* DVCUserTest.swift in Sources */,
+				52A1139F27AB235C000B8285 /* EventQueueTests.swift in Sources */,
 				5256A99A2798716400E749FF /* ObjCDVCClientTests.m in Sources */,
 				5256A99B2798716400E749FF /* ObjcDVCUserTests.m in Sources */,
 				524F4E62276D20A600CB9069 /* DVCVariableTests.swift in Sources */,

--- a/DevCycle-iOS.xcodeproj/project.pbxproj
+++ b/DevCycle-iOS.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		52A487032788C0FF00DABA34 /* ObjCUserConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52A487022788C0FF00DABA34 /* ObjCUserConfig.swift */; };
 		52A48707278C9BE200DABA34 /* Log.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52A48706278C9BE200DABA34 /* Log.swift */; };
 		52A96990279F3AAA00D3A602 /* PlatformDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52A9698F279F3AAA00D3A602 /* PlatformDetails.swift */; };
+		52A96A0F27A0A7CF00D3A602 /* EventQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52A96A0E27A0A7CF00D3A602 /* EventQueue.swift */; };
 		52E693EA27567E2600B52375 /* DevCycleService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52E693E927567E2600B52375 /* DevCycleService.swift */; };
 		52E693ED2756816A00B52375 /* DVCConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52E693EC2756816A00B52375 /* DVCConfig.swift */; };
 		52E693F62758032500B52375 /* DevCycleServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52E693F52758032500B52375 /* DevCycleServiceTests.swift */; };
@@ -81,6 +82,7 @@
 		52A487022788C0FF00DABA34 /* ObjCUserConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjCUserConfig.swift; sourceTree = "<group>"; };
 		52A48706278C9BE200DABA34 /* Log.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Log.swift; sourceTree = "<group>"; };
 		52A9698F279F3AAA00D3A602 /* PlatformDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlatformDetails.swift; sourceTree = "<group>"; };
+		52A96A0E27A0A7CF00D3A602 /* EventQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventQueue.swift; sourceTree = "<group>"; };
 		52E693E927567E2600B52375 /* DevCycleService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DevCycleService.swift; sourceTree = "<group>"; };
 		52E693EC2756816A00B52375 /* DVCConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DVCConfig.swift; sourceTree = "<group>"; };
 		52E693F52758032500B52375 /* DevCycleServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DevCycleServiceTests.swift; sourceTree = "<group>"; };
@@ -215,6 +217,7 @@
 				5264A7BC2769381500FEDB43 /* Cache.swift */,
 				52A9698F279F3AAA00D3A602 /* PlatformDetails.swift */,
 				0F2DD759279EFA6B00540C9D /* CustomData.swift */,
+				52A96A0E27A0A7CF00D3A602 /* EventQueue.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -341,6 +344,7 @@
 				52E693ED2756816A00B52375 /* DVCConfig.swift in Sources */,
 				5264A7BD2769381600FEDB43 /* Cache.swift in Sources */,
 				52A486762784A3E600DABA34 /* ObjCDVCOptions.swift in Sources */,
+				52A96A0F27A0A7CF00D3A602 /* EventQueue.swift in Sources */,
 				52E693EA27567E2600B52375 /* DevCycleService.swift in Sources */,
 				5268DB6727501D6000D17A40 /* DVCUser.swift in Sources */,
 				5264A78727626A2200FEDB43 /* ObjCErrors.swift in Sources */,

--- a/DevCycle/DVCClient.swift
+++ b/DevCycle/DVCClient.swift
@@ -193,7 +193,19 @@ public class DVCClient {
             Log.error("Service not setup correctly")
             return
         }
-        self.eventQueue.flush(service: service, user: user, callback: callback)
+        self.eventQueue.flush(service: service, user: user) { error in
+            callback?(error)
+            if (!self.eventQueue.isEmpty()) {
+                self.scheduleFlush()
+            }
+        }
+    }
+    
+    func scheduleFlush() {
+        let delay = Double(self.options?.flushEventsIntervalMs ?? self.defaultFlushInterval) / 1000.0
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
+            self.flushEvents(callback: nil)
+        }
     }
     
     public class ClientBuilder {

--- a/DevCycle/DVCClient.swift
+++ b/DevCycle/DVCClient.swift
@@ -196,15 +196,11 @@ public class DVCClient {
         self.eventQueue.flush(service: service, user: user) { error in
             callback?(error)
             if (!self.eventQueue.isEmpty()) {
-                self.scheduleFlush()
+                let delay = Double(self.options?.flushEventsIntervalMs ?? self.defaultFlushInterval) / 1000.0
+                DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
+                    self.flushEvents(callback: nil)
+                }
             }
-        }
-    }
-    
-    func scheduleFlush() {
-        let delay = Double(self.options?.flushEventsIntervalMs ?? self.defaultFlushInterval) / 1000.0
-        DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
-            self.flushEvents(callback: nil)
         }
     }
     

--- a/DevCycle/DVCClient.swift
+++ b/DevCycle/DVCClient.swift
@@ -190,7 +190,7 @@ public class DVCClient {
             return
         }
         guard let service = self.service else {
-            Log.error("Service not setup correctly")
+            Log.error("Client not set up correctly")
             return
         }
         self.eventQueue.flush(service: service, user: user) { error in

--- a/DevCycle/Models/DVCEvent.swift
+++ b/DevCycle/Models/DVCEvent.swift
@@ -100,4 +100,15 @@ struct DVCAggregateEvents {
             }
         }
     }
+    
+    func getAllAggregateEvents() -> [DVCEvent] {
+        var allAggregateEvents: [DVCEvent] = []
+        allAggregateEvents.append(contentsOf: self.variableDefaulted.map { (_: String, defaultedEvent: DVCEvent) -> DVCEvent in
+            defaultedEvent
+        })
+        allAggregateEvents.append(contentsOf: self.variableEvaluated.map { (_: String, evaluatedEvent: DVCEvent) -> DVCEvent in
+            evaluatedEvent
+        })
+        return allAggregateEvents
+    }
 }

--- a/DevCycle/Models/EventQueue.swift
+++ b/DevCycle/Models/EventQueue.swift
@@ -40,12 +40,7 @@ class EventQueue {
         eventDispatchQueue.sync {
             self.flushing = true
             eventsToFlush = self.events
-            eventsToFlush.append(contentsOf: self.aggregateEventQueue.variableDefaulted.map { (_: String, defaultedEvent: DVCEvent) -> DVCEvent in
-                defaultedEvent
-            })
-            eventsToFlush.append(contentsOf: self.aggregateEventQueue.variableEvaluated.map { (_: String, evaluatedEvent: DVCEvent) -> DVCEvent in
-                evaluatedEvent
-            })
+            eventsToFlush.append(contentsOf: aggregateEventQueue.getAllAggregateEvents())
             self.clear()
         }
         Log.debug("Flushing events: \(eventsToFlush.count)")

--- a/DevCycle/Models/EventQueue.swift
+++ b/DevCycle/Models/EventQueue.swift
@@ -1,0 +1,57 @@
+//
+//  EventQueue.swift
+//  DevCycle
+//
+//  Copyright © 2022 Taplytics. All rights reserved.
+//
+
+import Foundation
+
+class EventQueue {
+    var queue = DispatchQueue(label: "com.devcycle.EventQueue")
+    var events: [DVCEvent] = []
+    var aggregateEventQueue: DVCAggregateEvents = DVCAggregateEvents()
+    
+    func add(_ event: DVCEvent) {
+        queue.sync {
+            events.append(event)
+        }
+    }
+    
+    func add(_ events: [DVCEvent]) {
+        queue.sync {
+            self.events.append(contentsOf: events)
+        }
+    }
+    
+    func flush() -> [DVCEvent] {
+        var eventsToFlush: [DVCEvent] = []
+        queue.sync {
+            eventsToFlush = self.events
+            eventsToFlush.append(contentsOf: self.aggregateEventQueue.variableDefaulted.map { (_: String, defaultedEvent: DVCEvent) -> DVCEvent in
+                defaultedEvent
+            })
+            eventsToFlush.append(contentsOf: self.aggregateEventQueue.variableEvaluated.map { (_: String, evaluatedEvent: DVCEvent) -> DVCEvent in
+                evaluatedEvent
+            })
+            self.clear()
+        }
+        return eventsToFlush
+    }
+    
+    func updateAggregateEvents(variableKey: String, variableIsDefaulted: Bool) {
+        queue.sync {
+            self.aggregateEventQueue.track(
+                variableKey: variableKey,
+                eventType: variableIsDefaulted ? DVCEventTypes.VariableDefaulted : DVCEventTypes.VariableEvaluated
+            )
+        }
+    }
+    
+    func clear() {
+        queue.sync {
+            self.events = []
+            self.aggregateEventQueue = DVCAggregateEvents()
+        }
+    }
+}

--- a/DevCycle/Models/EventQueue.swift
+++ b/DevCycle/Models/EventQueue.swift
@@ -51,10 +51,6 @@ class EventQueue {
         Log.debug("Flushing events: \(eventsToFlush.count)")
         service.publishEvents(events: eventsToFlush, user: user, completion: { data, response, error in
             
-            self.eventDispatchQueue.async {
-                self.flushing = false
-            }
-            
             if let error = error {
                 Log.error("Error: \(error)", tags: ["events", "flush"])
                 self.queue(eventsToFlush)
@@ -62,8 +58,18 @@ class EventQueue {
                 Log.info("Submitted: \(String(describing: eventsToFlush.count)) events", tags: ["events", "flush"])
             }
             
+            self.eventDispatchQueue.async {
+                self.flushing = false
+            }
+            
             callback?(error)
         })
+    }
+    
+    func isEmpty() -> Bool {
+        eventDispatchQueue.sync {
+            return self.events.isEmpty
+        }
     }
     
     func updateAggregateEvents(variableKey: String, variableIsDefaulted: Bool) {

--- a/DevCycle/Models/EventQueue.swift
+++ b/DevCycle/Models/EventQueue.swift
@@ -23,7 +23,7 @@ class EventQueue {
         }
     }
     
-    func add(_ events: [DVCEvent]) {
+    func queue(_ events: [DVCEvent]) {
         eventDispatchQueue.async {
             self.events.append(contentsOf: events)
         }
@@ -57,7 +57,7 @@ class EventQueue {
             
             if let error = error {
                 Log.error("Error: \(error)", tags: ["events", "flush"])
-                self.add(eventsToFlush)
+                self.queue(eventsToFlush)
             } else {
                 Log.info("Submitted: \(String(describing: eventsToFlush.count)) events", tags: ["events", "flush"])
             }

--- a/DevCycleTests/DVCClientTest.swift
+++ b/DevCycleTests/DVCClientTest.swift
@@ -53,7 +53,7 @@ class DVCClientTest: XCTestCase {
         let event: DVCEvent = try! DVCEvent.builder().type("test").build()
         
         client.track(event)
-        XCTAssertTrue(client.eventQueue.count == 1)
+        XCTAssertTrue(client.eventQueue.events.count == 1)
     }
     
     func testTrackWithValidDVCEventWithAllParamsDefined() {
@@ -62,7 +62,7 @@ class DVCClientTest: XCTestCase {
         let event: DVCEvent = try! DVCEvent.builder().type("test").target("test").clientDate(Date()).value(1).metaData(metaData).build()
         
         client.track(event)
-        XCTAssertTrue(client.eventQueue.count == 1)
+        XCTAssertTrue(client.eventQueue.events.count == 1)
     }
     
     func testFlushEventsWithOneEventInQueue() {
@@ -74,7 +74,7 @@ class DVCClientTest: XCTestCase {
         let event: DVCEvent = try! DVCEvent.builder().type("test").clientDate(Date()).build()
         
         client.track(event)
-        XCTAssertTrue(client.eventQueue.count == 1)
+        XCTAssertTrue(client.eventQueue.events.count == 1)
         client.flushEvents()
         XCTAssertTrue(service.publishCallCount == 1)
     }

--- a/DevCycleTests/DVCClientTest.swift
+++ b/DevCycleTests/DVCClientTest.swift
@@ -78,27 +78,6 @@ class DVCClientTest: XCTestCase {
         client.flushEvents()
         XCTAssertTrue(service.publishCallCount == 1)
     }
-    
-    func testPeriodicFlushEventsWithSomeEventsInQueue() {
-        let user = getTestUser()
-        let options = DVCOptions.builder().disableEventLogging(false).flushEventsIntervalMs(500).build()
-        let client = try! DVCClient.builder().user(user).environmentKey("my_env_key").options(options).build(onInitialized: nil)
-        let service = MockService() // will assert if publishEvents was called
-        client.setup(service: service)
-        let event: DVCEvent = try! DVCEvent.builder().type("test").clientDate(Date()).build()
-        
-        client.track(event)
-        client.track(event)
-        client.track(event)
-        XCTAssertTrue(client.eventQueue.count == 3)
-        let expec = expectation(description: "Timer expectation") // create an expectation
-        service.publishEvents(events: client.eventQueue, user: user, completion: { data, response, error in
-            expec.fulfill()
-        })
-        // wait for fulfilling every expectation (in this case only one), timeout must be greater than the timer interval
-        wait(for: [expec], timeout: 1.0)
-        XCTAssertTrue(service.publishCallCount == 1)
-    }
 }
 
 extension DVCClientTest {

--- a/DevCycleTests/DVCClientTest.swift
+++ b/DevCycleTests/DVCClientTest.swift
@@ -49,23 +49,38 @@ class DVCClientTest: XCTestCase {
     }
     
     func testTrackWithValidDVCEventNoOptionals() {
+        let expectation = XCTestExpectation(description: "EventQueue has one event")
         let client = DVCClient()
         let event: DVCEvent = try! DVCEvent.builder().type("test").build()
         
         client.track(event)
-        XCTAssertTrue(client.eventQueue.events.count == 1)
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            XCTAssertTrue(client.eventQueue.events.count == 1)
+            expectation.fulfill()
+        }
+        
+        wait(for: [expectation], timeout: 1.0)
     }
     
     func testTrackWithValidDVCEventWithAllParamsDefined() {
+        let expectation = XCTestExpectation(description: "EventQueue has one fully defined event")
         let client = DVCClient()
         let metaData: [String:Any] = ["test1": "key", "test2": 2, "test3": false]
         let event: DVCEvent = try! DVCEvent.builder().type("test").target("test").clientDate(Date()).value(1).metaData(metaData).build()
         
         client.track(event)
-        XCTAssertTrue(client.eventQueue.events.count == 1)
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            XCTAssertTrue(client.eventQueue.events.count == 1)
+            expectation.fulfill()
+        }
+        
+        wait(for: [expectation], timeout: 1.0)
     }
     
     func testFlushEventsWithOneEventInQueue() {
+        let expectation = XCTestExpectation(description: "EventQueue publishes an event")
         let user = getTestUser()
         let options = DVCOptions.builder().disableEventLogging(false).flushEventsIntervalMs(10000).build()
         let client = try! DVCClient.builder().user(user).environmentKey("my_env_key").options(options).build(onInitialized: nil)
@@ -74,9 +89,13 @@ class DVCClientTest: XCTestCase {
         let event: DVCEvent = try! DVCEvent.builder().type("test").clientDate(Date()).build()
         
         client.track(event)
-        XCTAssertTrue(client.eventQueue.events.count == 1)
         client.flushEvents()
-        XCTAssertTrue(service.publishCallCount == 1)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            XCTAssertTrue(service.publishCallCount == 1)
+            expectation.fulfill()
+        }
+        
+        wait(for: [expectation], timeout: 1.0)
     }
 }
 

--- a/DevCycleTests/EventQueueTests.swift
+++ b/DevCycleTests/EventQueueTests.swift
@@ -1,0 +1,53 @@
+//
+//  EventQueueTests.swift
+//  DevCycleTests
+//
+//  Copyright © 2022 Taplytics. All rights reserved.
+//
+
+import XCTest
+@testable import DevCycle
+
+class EventQueueTests: XCTestCase {
+    
+    func testSerialOrderOfEvents() {
+        let eventQueue = EventQueue()
+        let expectation = XCTestExpectation(description: "Events are serially queued")
+        let event1 = try! DVCEvent.builder().type("event1").build()
+        let event2 = try! DVCEvent.builder().type("event2").build()
+        eventQueue.queue(event1)
+        eventQueue.queue(event2)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+            XCTAssert(eventQueue.events.first?.type == "event1")
+            XCTAssert(eventQueue.events.last?.type == "event2")
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 3.0)
+    }
+
+    func testFlushCancelsIfFlushInProgress() {
+        let eventQueue = EventQueue()
+        let expectation = XCTestExpectation(description: "Subsequent flushes are cancelled")
+        let event = try! DVCEvent.builder().type("event1").build()
+        let user = try! DVCUser.builder().userId("user1").build()
+        eventQueue.queue(event)
+        eventQueue.flush(service: MockService(), user: user, callback: nil)
+        eventQueue.flush(service: MockService(), user: user) { error in
+            XCTAssertNotNil(error)
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 3.0)
+    }
+}
+
+class MockService: DevCycleServiceProtocol {
+    func getConfig(user: DVCUser, completion: @escaping ConfigCompletionHandler) {}
+    
+    func publishEvents(events: [DVCEvent], user: DVCUser, completion: @escaping PublishEventsCompletionHandler) {
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+            completion((nil, nil, nil))
+        }
+    }
+    
+}

--- a/Examples/DevCycle-Example-App/DevCycle-Example-App.xcodeproj/project.pbxproj
+++ b/Examples/DevCycle-Example-App/DevCycle-Example-App.xcodeproj/project.pbxproj
@@ -7,7 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		0F722D1C2798695F00A4BB52 /* DevCycle.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0F722D1B2798695F00A4BB52 /* DevCycle.framework */; };
+		52A1139D27AAEB81000B8285 /* DevCycle.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 52A1139A27AAEB74000B8285 /* DevCycle.framework */; };
 		52A4869E2785F68C00DABA34 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52A4869D2785F68C00DABA34 /* AppDelegate.swift */; };
 		52A486A02785F68C00DABA34 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52A4869F2785F68C00DABA34 /* SceneDelegate.swift */; };
 		52A486A22785F68C00DABA34 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52A486A12785F68C00DABA34 /* ViewController.swift */; };
@@ -18,32 +18,24 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		0F722D07279868CA00A4BB52 /* PBXContainerItemProxy */ = {
+		52A1139927AAEB74000B8285 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = 0F722D00279868C300A4BB52 /* DevCycle-iOS.xcodeproj */;
+			containerPortal = 52A1139427AAEB74000B8285 /* DevCycle-iOS.xcodeproj */;
 			proxyType = 2;
 			remoteGlobalIDString = 5268DB4D27501CFC00D17A40;
 			remoteInfo = DevCycle;
 		};
-		0F722D09279868CA00A4BB52 /* PBXContainerItemProxy */ = {
+		52A1139B27AAEB74000B8285 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = 0F722D00279868C300A4BB52 /* DevCycle-iOS.xcodeproj */;
+			containerPortal = 52A1139427AAEB74000B8285 /* DevCycle-iOS.xcodeproj */;
 			proxyType = 2;
 			remoteGlobalIDString = 5268DB5627501CFC00D17A40;
 			remoteInfo = DevCycleTests;
 		};
-		0F722D0B279868CF00A4BB52 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 0F722D00279868C300A4BB52 /* DevCycle-iOS.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 5268DB4C27501CFC00D17A40;
-			remoteInfo = DevCycle;
-		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		0F722D00279868C300A4BB52 /* DevCycle-iOS.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = "DevCycle-iOS.xcodeproj"; path = "../../DevCycle-iOS.xcodeproj"; sourceTree = "<group>"; };
-		0F722D1B2798695F00A4BB52 /* DevCycle.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = DevCycle.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		52A1139427AAEB74000B8285 /* DevCycle-iOS.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = "DevCycle-iOS.xcodeproj"; path = "../../DevCycle-iOS.xcodeproj"; sourceTree = "<group>"; };
 		52A4869A2785F68C00DABA34 /* DevCycle-Example-App.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "DevCycle-Example-App.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		52A4869D2785F68C00DABA34 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		52A4869F2785F68C00DABA34 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -60,18 +52,18 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				0F722D1C2798695F00A4BB52 /* DevCycle.framework in Frameworks */,
+				52A1139D27AAEB81000B8285 /* DevCycle.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		0F722D03279868CA00A4BB52 /* Products */ = {
+		52A1139527AAEB74000B8285 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				0F722D08279868CA00A4BB52 /* DevCycle.framework */,
-				0F722D0A279868CA00A4BB52 /* DevCycleTests.xctest */,
+				52A1139A27AAEB74000B8285 /* DevCycle.framework */,
+				52A1139C27AAEB74000B8285 /* DevCycleTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -79,7 +71,6 @@
 		52A486912785F68C00DABA34 = {
 			isa = PBXGroup;
 			children = (
-				52A486B12785F6CA00DABA34 /* DevCycle */,
 				52A4869C2785F68C00DABA34 /* DevCycle-Example-App */,
 				52A4869B2785F68C00DABA34 /* Products */,
 				52A486BB2785F6EC00DABA34 /* Frameworks */,
@@ -109,18 +100,10 @@
 			path = "DevCycle-Example-App";
 			sourceTree = "<group>";
 		};
-		52A486B12785F6CA00DABA34 /* DevCycle */ = {
-			isa = PBXGroup;
-			children = (
-				0F722D00279868C300A4BB52 /* DevCycle-iOS.xcodeproj */,
-			);
-			path = DevCycle;
-			sourceTree = "<group>";
-		};
 		52A486BB2785F6EC00DABA34 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				0F722D1B2798695F00A4BB52 /* DevCycle.framework */,
+				52A1139427AAEB74000B8285 /* DevCycle-iOS.xcodeproj */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -147,7 +130,6 @@
 			buildRules = (
 			);
 			dependencies = (
-				0F722D0C279868CF00A4BB52 /* PBXTargetDependency */,
 			);
 			name = "DevCycle-Example-App";
 			productName = "DevCycle-Example-App";
@@ -182,8 +164,8 @@
 			projectDirPath = "";
 			projectReferences = (
 				{
-					ProductGroup = 0F722D03279868CA00A4BB52 /* Products */;
-					ProjectRef = 0F722D00279868C300A4BB52 /* DevCycle-iOS.xcodeproj */;
+					ProductGroup = 52A1139527AAEB74000B8285 /* Products */;
+					ProjectRef = 52A1139427AAEB74000B8285 /* DevCycle-iOS.xcodeproj */;
 				},
 			);
 			projectRoot = "";
@@ -194,18 +176,18 @@
 /* End PBXProject section */
 
 /* Begin PBXReferenceProxy section */
-		0F722D08279868CA00A4BB52 /* DevCycle.framework */ = {
+		52A1139A27AAEB74000B8285 /* DevCycle.framework */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.framework;
 			path = DevCycle.framework;
-			remoteRef = 0F722D07279868CA00A4BB52 /* PBXContainerItemProxy */;
+			remoteRef = 52A1139927AAEB74000B8285 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		0F722D0A279868CA00A4BB52 /* DevCycleTests.xctest */ = {
+		52A1139C27AAEB74000B8285 /* DevCycleTests.xctest */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.cfbundle;
 			path = DevCycleTests.xctest;
-			remoteRef = 0F722D09279868CA00A4BB52 /* PBXContainerItemProxy */;
+			remoteRef = 52A1139B27AAEB74000B8285 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 /* End PBXReferenceProxy section */
@@ -236,14 +218,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
-
-/* Begin PBXTargetDependency section */
-		0F722D0C279868CF00A4BB52 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = DevCycle;
-			targetProxy = 0F722D0B279868CF00A4BB52 /* PBXContainerItemProxy */;
-		};
-/* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
 		52A486A32785F68C00DABA34 /* Main.storyboard */ = {

--- a/Examples/DevCycle-Example-App/DevCycle-Example-App/ViewController.swift
+++ b/Examples/DevCycle-Example-App/DevCycle-Example-App/ViewController.swift
@@ -56,15 +56,18 @@ class ViewController: UIViewController {
     
     @IBAction func track(_ sender: Any) {
         guard let client = self.client else { return }
-        let event = try? DVCEvent.builder()
+        let event = try! DVCEvent.builder()
                                  .type("my_event")
                                  .target("my_target")
                                  .value(3)
                                  .metaData([ "key": "value" ])
                                  .clientDate(Date())
                                  .build()
-        if let event = event {
-            client.track(event)
+        client.track(event)
+        client.flushEvents { error in
+            if (error != nil) {
+                print("Error")
+            }
         }
     }
     

--- a/Examples/DevCycle-Example-App/DevCycle-Example-App/ViewController.swift
+++ b/Examples/DevCycle-Example-App/DevCycle-Example-App/ViewController.swift
@@ -64,11 +64,6 @@ class ViewController: UIViewController {
                                  .clientDate(Date())
                                  .build()
         client.track(event)
-        client.flushEvents { error in
-            if (error != nil) {
-                print("Error")
-            }
-        }
     }
     
     @IBAction func logAllFeatures(_ sender: Any) {

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -21,7 +21,8 @@ platform :ios do
     run_tests(
       derived_data_path: "~/Library/Developer/Xcode/DerivedData",
       buildlog_path: "./fastlane/fastlane-buildlog",
-      scheme: "DevCycle"
+      scheme: "DevCycle",
+      result_bundle: true
     )
   end
 end


### PR DESCRIPTION
# Changes

- user can now use a callback when calling `flushEvents`
- when a flush is finished, if the queue is not empty again it will schedule a flush (an error with the flush will cause it to re-add to the queue, which will then trigger a scheduled flush)
- removed timer that persisted indefinitely