### PR TITLE
fix: setting is anonymous to false and passing in no user_id now doesn't create dvcuser

### DIFF
--- a/DevCycle/DVCUser.swift
+++ b/DevCycle/DVCUser.swift
@@ -36,7 +36,9 @@ public class UserBuilder {
     public func isAnonymous(_ isAnonymous: Bool) -> UserBuilder {
         if (self.user.isAnonymous != nil) { return self }
         self.user.isAnonymous = isAnonymous
-        self.user.userId = UUID().uuidString
+        if (isAnonymous) {
+            self.user.userId = UUID().uuidString
+        }
         return self
     }
     

--- a/DevCycleTests/DVCUserTest.swift
+++ b/DevCycleTests/DVCUserTest.swift
@@ -25,6 +25,13 @@ class DVCUserTest: XCTestCase {
         XCTAssertNil(user)
     }
     
+    func testBuilderReturnsNilIfNoUserIdAndIsAnonymousIsFalse() {
+        let user = try? DVCUser.builder()
+                    .isAnonymous(false)
+                    .build()
+        XCTAssertNil(user)
+    }
+    
     func testBuilderReturnsUserIfUserIdSet() {
         let user = try! DVCUser.builder().userId("my_user").build()
         XCTAssertNotNil(user)


### PR DESCRIPTION
# Changes

- when creating user, setting `isAnonymous` to `false` and passing in no `user_id` still made an anonymous `user_id`, now it fails to create one 