### PR TITLE
feat: enable edge DB on iOS

### DIFF
--- a/DevCycle/DVCClient.swift
+++ b/DevCycle/DVCClient.swift
@@ -77,11 +77,11 @@ public class DVCClient {
                 }
                 self.config?.userConfig = config
                 
-                if (self.checkIfEdgeDBEnabled(config: (self.config?.userConfig)!, enableEdgeDB: self.enableEdgeDB)) {
+                if (self.checkIfEdgeDBEnabled(config: config!, enableEdgeDB: self.enableEdgeDB)) {
                     if (!(user.isAnonymous ?? false)) {
                         self.service?.saveEntity(user: user, completion: { data, response, error in
                             if error != nil {
-                                Log.error("Error saving user entity")
+                                Log.error("Error saving user entity for \(user). Error: \(String(describing: error))")
                             } else {
                                 Log.info("Saved user entity")
                             }

--- a/DevCycle/Models/DVCOptions.swift
+++ b/DevCycle/Models/DVCOptions.swift
@@ -10,6 +10,7 @@ public class DVCOptions {
     var flushEventsIntervalMs: Int?
     var disableEventLogging: Bool?
     var logLevel: LogLevel = .error
+    var enableEdgeDB: Bool = false
     
     public class OptionsBuilder {
         var options: DVCOptions
@@ -30,6 +31,11 @@ public class DVCOptions {
         
         public func logLevel(_ level: LogLevel) -> OptionsBuilder {
             self.options.logLevel = level
+            return self
+        }
+        
+        public func enableEdgeDB(_ enable: Bool) -> OptionsBuilder {
+            self.options.enableEdgeDB = enable
             return self
         }
         

--- a/DevCycle/Models/UserConfig.swift
+++ b/DevCycle/Models/UserConfig.swift
@@ -56,12 +56,35 @@ public struct UserConfig {
 public struct Project {
     var _id: String
     var key: String
+    var settings: Settings
     
     init (from dictionary: [String: Any]) throws {
         guard let key = dictionary["key"] as? String else { throw UserConfigError.MissingProperty("key in Project") }
         guard let id = dictionary["_id"] as? String else { throw UserConfigError.MissingProperty("_id in Project") }
+        let settings = dictionary["settings"] as? [String:Any]
         self._id = id
         self.key = key
+        self.settings = Settings(from: settings ?? ["edgeDB": ["enabled": false]])
+    }
+}
+
+struct Settings {
+    var edgeDB: EdgeDB
+    
+    init(from dictionary: [String: Any]) {
+        let edgeDB = dictionary["edgeDB"] as? [String: Any]
+        
+        self.edgeDB = EdgeDB(from: edgeDB ?? ["enabled": false])
+    }
+}
+
+struct EdgeDB {
+    var enabled: Bool
+    
+    init(from dictionary: [String: Any]) {
+        let enabled = dictionary["enabled"] as? Bool
+
+        self.enabled = enabled ?? false
     }
 }
 

--- a/DevCycle/Networking/DevCycleService.swift
+++ b/DevCycle/Networking/DevCycleService.swift
@@ -160,6 +160,7 @@ class DevCycleService: DevCycleServiceProtocol {
         }
         
         let userEncoder = JSONEncoder()
+        userEncoder.dateEncodingStrategy = .iso8601
         
         guard let userData = try? userEncoder.encode(user) else {
             return completion((nil, nil, ClientError.MissingUserOrFeatureVariationsMap))

--- a/DevCycle/Networking/DevCycleService.swift
+++ b/DevCycle/Networking/DevCycleService.swift
@@ -181,10 +181,7 @@ class DevCycleService: DevCycleServiceProtocol {
         saveEntityRequest.httpBody = jsonBody
         
         self.makeRequest(request: saveEntityRequest) { data, response, error in
-            if error != nil || data == nil {
-                return completion((data, response, error))
-            }
-            return completion((data, response, nil))
+            return completion((data, response, error))
         }
     }
 

--- a/DevCycle/Networking/DevCycleService.swift
+++ b/DevCycle/Networking/DevCycleService.swift
@@ -170,15 +170,18 @@ class DevCycleService: DevCycleServiceProtocol {
             return completion((nil, nil, ClientError.MissingUserOrFeatureVariationsMap))
         }
         
-        let jsonBody = try? JSONSerialization.data(withJSONObject: userBody, options: .prettyPrinted)
-        
         saveEntityRequest.httpMethod = "PATCH"
         saveEntityRequest.addValue("application/json", forHTTPHeaderField: "Content-Type")
         saveEntityRequest.addValue("application/json", forHTTPHeaderField: "Accept")
         saveEntityRequest.addValue(config.environmentKey, forHTTPHeaderField: "Authorization")
-        Log.info("Save entity payload: \(String(data: jsonBody!, encoding: .utf8) ?? "")")
-        
-        saveEntityRequest.httpBody = jsonBody
+        if let jsonBody = try? JSONSerialization.data(withJSONObject: userBody, options: .prettyPrinted) {
+           // build the save entity request with this data object
+            Log.info("Save entity payload: \(String(data: jsonBody, encoding: .utf8) ?? "")")
+            saveEntityRequest.httpBody = jsonBody
+        } else {
+            Log.error("Invalid user data")
+            return completion((nil, nil, ClientError.InvalidUser))
+        }
         
         self.makeRequest(request: saveEntityRequest) { data, response, error in
             return completion((data, response, error))

--- a/DevCycle/ObjC/ObjCDVCOptions.swift
+++ b/DevCycle/ObjC/ObjCDVCOptions.swift
@@ -19,6 +19,7 @@ public class ObjCOptions: NSObject {
     @objc public var flushEventsIntervalMs: NSNumber?
     @objc public var disableEventLogging: NSNumber?
     @objc public var logLevel: NSNumber?
+    @objc public var enableEdgeDB: NSNumber?
     
     func buildDVCOptions() -> DVCOptions {
         var optionsBuilder = DVCOptions.builder()
@@ -31,6 +32,12 @@ public class ObjCOptions: NSObject {
            let disable = disableEventLogging as? Bool {
             optionsBuilder = optionsBuilder.disableEventLogging(disable)
         }
+        
+        if let enableEdgeDB = self.enableEdgeDB,
+           let enable = enableEdgeDB as? Bool {
+            optionsBuilder = optionsBuilder.enableEdgeDB(enable)
+        }
+        
         if let logLevel = self.logLevel,
            let level = logLevel as? Int {
             var setLogLevel = LogLevel.error

--- a/DevCycleTests/DVCClientTest.swift
+++ b/DevCycleTests/DVCClientTest.swift
@@ -103,7 +103,7 @@ extension DVCClientTest {
     class MockService: DevCycleServiceProtocol {
         public var publishCallCount: Int = 0
         
-        func getConfig(user: DVCUser, completion: @escaping ConfigCompletionHandler) {
+        func getConfig(user: DVCUser, enableEdgeDB: Bool, completion: @escaping ConfigCompletionHandler) {
             XCTAssert(true)
         }
 
@@ -111,6 +111,10 @@ extension DVCClientTest {
             self.publishCallCount += 1
             XCTAssert(true)
             completion((data: nil, urlResponse: nil, error: nil))
+        }
+        
+        func saveEntity(user: DVCUser, completion: @escaping SaveEntityCompletionHandler) {
+            XCTAssert(true)
         }
     }
     

--- a/DevCycleTests/DVCOptionsTest.swift
+++ b/DevCycleTests/DVCOptionsTest.swift
@@ -23,7 +23,7 @@ class DVCOptionsTest: XCTestCase {
         XCTAssertNotNil(options)
         XCTAssert(options.flushEventsIntervalMs == 1000)
         XCTAssertFalse(options.disableEventLogging!)
-        XCTAssertTrue(options.enableEdgeDB)
+        XCTAssert(options.enableEdgeDB)
     }
     
     func testBuilderReturnsOptionsAndSomeAreNil() {

--- a/DevCycleTests/DVCOptionsTest.swift
+++ b/DevCycleTests/DVCOptionsTest.swift
@@ -18,10 +18,12 @@ class DVCOptionsTest: XCTestCase {
         let options = DVCOptions.builder()
                 .disableEventLogging(false)
                 .flushEventsIntervalMs(1000)
+                .enableEdgeDB(true)
                 .build()
         XCTAssertNotNil(options)
         XCTAssert(options.flushEventsIntervalMs == 1000)
         XCTAssertFalse(options.disableEventLogging!)
+        XCTAssertTrue(options.enableEdgeDB)
     }
     
     func testBuilderReturnsOptionsAndSomeAreNil() {
@@ -31,5 +33,6 @@ class DVCOptionsTest: XCTestCase {
         XCTAssertNotNil(options)
         XCTAssertNil(options.flushEventsIntervalMs)
         XCTAssertFalse(options.disableEventLogging!)
+        XCTAssertFalse(options.enableEdgeDB)
     }
 }

--- a/DevCycleTests/DevCycleServiceTests.swift
+++ b/DevCycleTests/DevCycleServiceTests.swift
@@ -29,6 +29,12 @@ class DevCycleServiceTests: XCTestCase {
         XCTAssertFalse(url!.contains("user_id=my_user"))
     }
     
+    func testCreateSaveEntityRequest() throws {
+        let url = getService().createSaveEntityRequest().url?.absoluteString
+        XCTAssert(url!.contains("https://sdk-api.devcycle.com/v1/edgedb"))
+        XCTAssert(url!.contains("my_user"))
+    }
+    
     func testProcessConfigReturnsNilIfMissingProperties() throws {
         let service = getService()
         let data = "{\"config\":\"key\"}".data(using: .utf8)

--- a/DevCycleTests/DevCycleServiceTests.swift
+++ b/DevCycleTests/DevCycleServiceTests.swift
@@ -9,10 +9,18 @@ import XCTest
 
 class DevCycleServiceTests: XCTestCase {
     func testCreateConfigURLRequest() throws {
-        let url = getService().createConfigRequest(user: getTestUser()).url?.absoluteString
+        let url = getService().createConfigRequest(user: getTestUser(), enableEdgeDB: false).url?.absoluteString
         XCTAssert(url!.contains("https://sdk-api.devcycle.com/v1/mobileSDKConfig"))
         XCTAssert(url!.contains("envKey=my_env_key"))
         XCTAssert(url!.contains("user_id=my_user"))
+    }
+    
+    func testCreateConfigURLRequestWithEdgeDB() throws {
+        let url = getService().createConfigRequest(user: getTestUser(), enableEdgeDB: true).url?.absoluteString
+        XCTAssert(url!.contains("https://sdk-api.devcycle.com/v1/mobileSDKConfig"))
+        XCTAssert(url!.contains("envKey=my_env_key"))
+        XCTAssert(url!.contains("user_id=my_user"))
+        XCTAssert(url!.contains("enableEdgeDB=true"))
     }
     
     func testCreateEventURLRequest() throws {
@@ -53,7 +61,7 @@ class DevCycleServiceTests: XCTestCase {
         let exp = expectation(description: "Saves user to cache")
         
         let user = try! DVCUser.builder().userId("dummy_user").build()
-        service.getConfig(user: user) { config in
+        service.getConfig(user: user, enableEdgeDB: false) { config in
             XCTAssert((service.cacheService as! MockCacheService).saveUserCalled)
             exp.fulfill()
         }

--- a/DevCycleTests/EventQueueTests.swift
+++ b/DevCycleTests/EventQueueTests.swift
@@ -41,7 +41,7 @@ class EventQueueTests: XCTestCase {
 }
 
 class MockService: DevCycleServiceProtocol {
-    func getConfig(user: DVCUser, completion: @escaping ConfigCompletionHandler) {}
+    func getConfig(user: DVCUser, enableEdgeDB: Bool, completion: @escaping ConfigCompletionHandler) {}
     
     func publishEvents(events: [DVCEvent], user: DVCUser, completion: @escaping PublishEventsCompletionHandler) {
         
@@ -49,5 +49,7 @@ class MockService: DevCycleServiceProtocol {
             completion((nil, nil, nil))
         }
     }
+    
+    func saveEntity(user: DVCUser, completion: @escaping SaveEntityCompletionHandler) {}
     
 }


### PR DESCRIPTION
- follows similar logic to js sdk
- calls `saveEntity` on initialize
- add tests and fix existing tests