### PR TITLE
chore: return default for unsupported keys for dvc variable calls

### DIFF
--- a/DevCycle/DVCClient.swift
+++ b/DevCycle/DVCClient.swift
@@ -130,6 +130,18 @@ public class DVCClient {
     
     public func variable<T>(key: String, defaultValue: T) -> DVCVariable<T> {
         var variable: DVCVariable<T>
+        let regex = try? NSRegularExpression(pattern: ".*[^a-z0-9(\\-)(_)].*")
+        if (regex?.firstMatch(in: key, range: NSMakeRange(0, key.count)) != nil) {
+            Log.error("The variable key \(key) is invalid. It must contain only lowercase letters, numbers, hyphens and underscores. The default value will always be returned for this call.")
+            return DVCVariable(
+                key: key,
+                type: String(describing: T.self),
+                value: nil,
+                defaultValue: defaultValue,
+                evalReason: nil
+            )
+        }
+        
         if let config = self.config?.userConfig,
            let variableFromApi = config.variables[key] {
             variable = DVCVariable(from: variableFromApi, defaultValue: defaultValue)

--- a/DevCycleTests/DVCClientTest.swift
+++ b/DevCycleTests/DVCClientTest.swift
@@ -97,6 +97,22 @@ class DVCClientTest: XCTestCase {
         
         wait(for: [expectation], timeout: 1.0)
     }
+    
+    func testVariableReturnsDefaultForUnsupportedVariableKeys() {
+        let user = getTestUser()
+        let client = try! DVCClient.builder().user(user).environmentKey("my_env_key").build(onInitialized: nil)
+        let variable = client.variable(key: "UNSUPPORTED\\key%$", defaultValue: true)
+        XCTAssertEqual(client.configCompletionHandlers.count, 0)
+        XCTAssertTrue(variable.value)
+    }
+    
+    func testVariableFunctionWorksIfVariableKeyHasSupportedCharacters() {
+        let user = getTestUser()
+        let client = try! DVCClient.builder().user(user).environmentKey("my_env_key").build(onInitialized: nil)
+        let variable = client.variable(key: "supported-keys_here", defaultValue: true)
+        XCTAssertEqual(client.configCompletionHandlers.count, 1)
+    }
+
 }
 
 extension DVCClientTest {


### PR DESCRIPTION
# Summary

For `variable` calls, return early and log an error if the key has any unsupported characters: i.e. not in `a-z0-9(-)(_)`