### PR TITLE
feat: refetch config when sse message is received

### DIFF
--- a/DevCycle-iOS.xcodeproj/project.pbxproj
+++ b/DevCycle-iOS.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0B721685290B21CD004D0AB7 /* SSEMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B721684290B21CD004D0AB7 /* SSEMessage.swift */; };
 		0F2DD75A279EFA6B00540C9D /* CustomData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F2DD759279EFA6B00540C9D /* CustomData.swift */; };
 		52133B2028DDFB260007691D /* RequestConsolidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52133B1F28DDFB260007691D /* RequestConsolidatorTests.swift */; };
 		52133B2228DE00BC0007691D /* ProcessConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52133B2128DE00BC0007691D /* ProcessConfig.swift */; };
@@ -78,6 +79,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		0B721684290B21CD004D0AB7 /* SSEMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSEMessage.swift; sourceTree = "<group>"; };
 		0F2DD759279EFA6B00540C9D /* CustomData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomData.swift; sourceTree = "<group>"; };
 		52133B1F28DDFB260007691D /* RequestConsolidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestConsolidatorTests.swift; sourceTree = "<group>"; };
 		52133B2128DE00BC0007691D /* ProcessConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessConfig.swift; sourceTree = "<group>"; };
@@ -199,6 +201,7 @@
 				52A1139E27AB235C000B8285 /* EventQueueTests.swift */,
 				5264A78F2768E9F400FEDB43 /* UserConfigTests.swift */,
 				5264A78D2768E94500FEDB43 /* test_config.json */,
+				0B721684290B21CD004D0AB7 /* SSEMessage.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -449,6 +452,7 @@
 				52133B2028DDFB260007691D /* RequestConsolidatorTests.swift in Sources */,
 				5276C9F2275E6E0D00B9A324 /* DVCOptionsTest.swift in Sources */,
 				5264A7902768E9F400FEDB43 /* UserConfigTests.swift in Sources */,
+				0B721685290B21CD004D0AB7 /* SSEMessage.swift in Sources */,
 				52E693F62758032500B52375 /* DevCycleServiceTests.swift in Sources */,
 				52404CED27F4A92100290A31 /* IsEqualTests.swift in Sources */,
 				5268DB6B275020F800D17A40 /* DVCClientTest.swift in Sources */,

--- a/DevCycle/Models/UserConfig.swift
+++ b/DevCycle/Models/UserConfig.swift
@@ -18,6 +18,7 @@ public struct UserConfig {
     var features: [String: Feature]
     var variables: [String: Variable]
     var sse: SSE?
+    var etag: String?
     
     init(from dictionary: [String:Any]) throws {
         guard let environment = dictionary["environment"] as? [String: Any] else { throw UserConfigError.MissingInConfig("environment") }
@@ -25,7 +26,8 @@ public struct UserConfig {
         guard let featureVariationMap = dictionary["featureVariationMap"] as? [String: String] else { throw UserConfigError.MissingInConfig("featureVariationMap") }
         guard var featureMap = dictionary["features"] as? [String: Any] else { throw UserConfigError.MissingInConfig("features") }
         guard var variablesMap = dictionary["variables"] as? [String: Any] else { throw UserConfigError.MissingInConfig("variables") }
-        var sse = dictionary["sse"] as? [String: Any]
+        let sse = dictionary["sse"] as? [String: Any]
+        let etag = dictionary["etag"] as? String
 
         
         self.project = try Project(from: project)
@@ -35,7 +37,11 @@ public struct UserConfig {
         if let definedSSE = sse {
             self.sse = try SSE(from: definedSSE)
         }
-        
+
+        if let etag = etag {
+            self.etag = etag
+        }
+
         let featureKeys = Array(featureMap.keys)
         let variableKeys = Array(variablesMap.keys)
         

--- a/DevCycle/SSEConnection.swift
+++ b/DevCycle/SSEConnection.swift
@@ -56,3 +56,29 @@ class Handler: EventHandler {
         Log.error("Streaming connection had an error: " + error.localizedDescription)
     }
 }
+
+public struct SSEMessage {
+    enum SSEMessageError: Error, Equatable {
+        case initError(String)
+    }
+    struct Data {
+        var etag: String?
+        var lastModified: Int?
+        var type: String?
+    }
+
+    var data: Data
+
+    init(from dictionary: [String: Any]) throws {
+        guard let data = dictionary["data"] as? String else {
+            throw SSEMessageError.initError("No data field in SSE JSON")
+        }
+        guard let dataDictionary = try? JSONSerialization.jsonObject(with: (data.data(using: .utf8))!, options: .fragmentsAllowed) as? [String: Any] else {
+            throw SSEMessageError.initError("Failed to parse data field in SSE message")
+        }
+        let etag = dataDictionary["etag"] as? String
+        let type = dataDictionary["type"] as? String
+        let lastModified = dataDictionary["lastModified"] as? Int
+        self.data = Data(etag: etag, lastModified: lastModified, type: type)
+    }
+}

--- a/DevCycleTests/Models/DVCClientTest.swift
+++ b/DevCycleTests/Models/DVCClientTest.swift
@@ -155,19 +155,19 @@ class DVCClientTest: XCTestCase {
         client.initialized = true
 
         XCTAssertEqual(client.lastIdentifiedUser?.userId, user1.userId)
-        client.refetchConfig()
+        client.refetchConfig(sse: true, lastModified: 123)
         XCTAssertEqual(service.numberOfConfigCalls, 2)
 
         let user2 = try! DVCUser.builder().userId("user2").build()
         try! client.identifyUser(user: user2)
         XCTAssertEqual(client.lastIdentifiedUser?.userId, user2.userId)
-        client.refetchConfig()
+        client.refetchConfig(sse: true, lastModified: 456)
         XCTAssertEqual(service.numberOfConfigCalls, 4)
 
         let user3 = try! DVCUser.builder().userId("user3").build()
         try! client.identifyUser(user: user3)
         XCTAssertEqual(client.lastIdentifiedUser?.userId, user3.userId)
-        client.refetchConfig()
+        client.refetchConfig(sse: true, lastModified: 789)
         XCTAssertEqual(service.numberOfConfigCalls, 6)
     }
 
@@ -180,7 +180,7 @@ extension DVCClientTest {
         public var numberOfConfigCalls: Int = 0
         public var eventPublishCount: Int = 0
 
-        func getConfig(user: DVCUser, enableEdgeDB: Bool, completion: @escaping ConfigCompletionHandler) {
+        func getConfig(user: DVCUser, enableEdgeDB: Bool, extraParams: RequestParams?, completion: @escaping ConfigCompletionHandler) {
             self.userForGetConfig = user
             self.numberOfConfigCalls += 1
 

--- a/DevCycleTests/Models/EventQueueTests.swift
+++ b/DevCycleTests/Models/EventQueueTests.swift
@@ -67,7 +67,7 @@ class EventQueueTests: XCTestCase {
 }
 
 private class MockService: DevCycleServiceProtocol {
-    func getConfig(user: DVCUser, enableEdgeDB: Bool, completion: @escaping ConfigCompletionHandler) {}
+    func getConfig(user: DVCUser, enableEdgeDB: Bool, extraParams: RequestParams?, completion: @escaping ConfigCompletionHandler) {}
     
     func publishEvents(events: [DVCEvent], user: DVCUser, completion: @escaping PublishEventsCompletionHandler) {
         
@@ -87,7 +87,7 @@ class MockWithErrorCodeService: DevCycleServiceProtocol {
         self.errorCode = errorCode
     }
     
-    func getConfig(user: DVCUser, enableEdgeDB: Bool, completion: @escaping ConfigCompletionHandler) {}
+    func getConfig(user: DVCUser, enableEdgeDB: Bool, extraParams: RequestParams?, completion: @escaping ConfigCompletionHandler) {}
     func publishEvents(events: [DVCEvent], user: DVCUser, completion: @escaping PublishEventsCompletionHandler) {
         let error = NSError(domain: "api.devcycle.com", code: self.errorCode)
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {

--- a/DevCycleTests/Models/SSEMessage.swift
+++ b/DevCycleTests/Models/SSEMessage.swift
@@ -1,0 +1,58 @@
+//
+//  SSEMessage.swift
+//  DevCycleTests
+//
+
+import XCTest
+@testable import DevCycle;
+
+class SSEMessageTests: XCTestCase {
+    func testShouldInitFromJson() throws {
+        let jsonData = """
+        {
+            \"id\":\"test_id\",
+            \"timestamp\":123,
+            \"channel\":\"dvc_mobile_test\",
+            \"data\":\"{\\\"etag\\\":\\\"\\\\\\\"123abc\\\\\\\"\\\",\\\"lastModified\\\":123}\",
+            \"name\":\"change\"
+        }
+        """.data(using: .utf8)
+
+        let dictionary = try JSONSerialization.jsonObject(with: jsonData!) as! [String: Any]
+        let sseMessage = try SSEMessage(from: dictionary)
+        XCTAssertNotNil(sseMessage.data)
+        XCTAssertNotNil(sseMessage.data.etag)
+        XCTAssertNotNil(sseMessage.data.lastModified)
+    }
+
+    func testShouldThrowInitErrorWhenDataFieldIsMissing() throws {
+        let jsonData = """
+        {
+            \"id\":\"test_id\",
+            \"timestamp\":123,
+            \"channel\":\"dvc_mobile_test\",
+            \"name\":\"change\"
+        }
+        """.data(using: .utf8)
+        let dictionary = try JSONSerialization.jsonObject(with: jsonData!) as! [String: Any]
+        XCTAssertThrowsError(try SSEMessage(from: dictionary)) { error in
+            XCTAssertEqual(error as! SSEMessage.SSEMessageError, SSEMessage.SSEMessageError.initError("No data field in SSE JSON"))
+        }
+    }
+
+    func testShouldThrowErrorWhenDataFieldIsUnparsable() throws {
+        let jsonData = """
+        {
+            \"id\":\"test_id\",
+            \"timestamp\":123,
+            \"channel\":\"dvc_mobile_test\",
+            \"data\":\"{\\\"etag\\\":123abc\\\\\\\",\\\"lastModified\\\":123}\",
+            \"name\":\"change\"
+        }
+        """.data(using: .utf8)
+        let dictionary = try JSONSerialization.jsonObject(with: jsonData!) as! [String: Any]
+        XCTAssertThrowsError(try SSEMessage(from: dictionary)) { error in
+            XCTAssertEqual(error as! SSEMessage.SSEMessageError, SSEMessage.SSEMessageError.initError("Failed to parse data field in SSE message"))
+        }
+    }
+}

--- a/DevCycleTests/Utils/RequestConsolidatorTests.swift
+++ b/DevCycleTests/Utils/RequestConsolidatorTests.swift
@@ -57,7 +57,7 @@ class RequestConsolidatorTests: XCTestCase {
 
 extension RequestConsolidatorTests {
     class MockService: DevCycleServiceProtocol {
-        func getConfig(user: DVCUser, enableEdgeDB: Bool, completion: @escaping ConfigCompletionHandler) {
+        func getConfig(user: DVCUser, enableEdgeDB: Bool, extraParams: RequestParams?, completion: @escaping ConfigCompletionHandler) {
             XCTAssert(true)
         }
 


### PR DESCRIPTION
# Changes
* refetch config when an sse message is received
* send `sse` and `sseLastModified` query params in config request
* add unit test for initializing an `SSEMessage` object