### PR TITLE
Initialize users as anonymous implicitly

### DIFF
--- a/DevCycle/DVCClient.swift
+++ b/DevCycle/DVCClient.swift
@@ -277,6 +277,8 @@ public class DVCClient {
     public func resetUser(callback: IdentifyCompletedHandler? = nil) throws {
         self.cache = cacheService.load()
         self.flushEvents()
+        
+        let cachedAnonUserId = self.cacheService.getAnonUserId()
         self.cacheService.clearAnonUserId()
         let anonUser = try DVCUser.builder().isAnonymous(true).build()
         
@@ -285,6 +287,9 @@ public class DVCClient {
         self.service?.getConfig(user: anonUser, enableEdgeDB: self.enableEdgeDB, extraParams: nil, completion: { [weak self] config, error in
             guard let self = self else { return }
             guard error == nil else {
+                if let previousAnonUserId = cachedAnonUserId {
+                    self.cacheService.setAnonUserId(anonUserId: previousAnonUserId)
+                }
                 callback?(error, nil)
                 return
             }

--- a/DevCycleTests/Models/DVCUserTest.swift
+++ b/DevCycleTests/Models/DVCUserTest.swift
@@ -50,6 +50,16 @@ class DVCUserTest: XCTestCase {
         XCTAssert(UUID(uuidString: user.userId!) != nil)
     }
     
+    func testBuilderReturnsNilIfUserIdIsEmptyString() {
+        let user = try? DVCUser.builder().userId("").build()
+        XCTAssertNil(user)
+    }
+    
+    func testBuilderReturnsNilIfUserIdOnlyContainsWhitespaces() {
+        let user = try? DVCUser.builder().userId(" ").build()
+        XCTAssertNil(user)
+    }
+    
     func testToStringOnlyOutputsNonNilProperties() {
         var components = URLComponents(string: "test.com")
         components?.queryItems = getTestUser().toQueryItems()

--- a/DevCycleTests/Models/DVCUserTest.swift
+++ b/DevCycleTests/Models/DVCUserTest.swift
@@ -19,17 +19,21 @@ class DVCUserTest: XCTestCase {
         XCTAssertNotNil(user.sdkVersion)
     }
 
-    func testBuilderReturnsNilIfNoUserIdOrIsAnonymous() {
-        let user = try? DVCUser.builder()
+    func testBuilderReturnsAnonUserIfNoUserIdOrIsAnonymous() {
+        let user = try! DVCUser.builder()
                     .build()
-        XCTAssertNil(user)
+        XCTAssertNotNil(user)
+        XCTAssert(UUID(uuidString: user.userId!) != nil)
+        XCTAssertTrue(user.isAnonymous!)
     }
     
-    func testBuilderReturnsNilIfNoUserIdAndIsAnonymousIsFalse() {
-        let user = try? DVCUser.builder()
+    func testBuilderReturnsAnonUserIfNoUserIdAndIsAnonymousIsFalse() {
+        let user = try! DVCUser.builder()
                     .isAnonymous(false)
                     .build()
-        XCTAssertNil(user)
+        XCTAssertNotNil(user)
+        XCTAssert(UUID(uuidString: user.userId!) != nil)
+        XCTAssertTrue(user.isAnonymous!)
     }
     
     func testBuilderReturnsUserIfUserIdSet() {


### PR DESCRIPTION
- if no `userId` is passed in, implied anonymous
- fix restoring cached id if `resetUser` fails
- update tests