### PR TITLE
fix config fetch in callback by setting requestInFlight flag

### DIFF
--- a/DevCycle/Utils/RequestConsolidator.swift
+++ b/DevCycle/Utils/RequestConsolidator.swift
@@ -40,8 +40,8 @@ class RequestConsolidator {
                 }
                 
                 self.cacheService.saveConfig(user: user, fetchDate: Int(Date().timeIntervalSince1970), configToSave: response.data)
-                callback((config, response.error))
                 self.requestInFlight = false
+                callback((config, response.error))
             } else {
                 self.requestCallbacks.insert(
                     RequestWithCallback(


### PR DESCRIPTION
- set the `requestInFlight` flag to false before the callback, as we've already processed the config at this point