### PR TITLE
[fix] convert DVCEvent value attribute to Double instead of Int

### DIFF
--- a/DevCycle/Models/DVCEvent.swift
+++ b/DevCycle/Models/DVCEvent.swift
@@ -14,10 +14,10 @@ public class DVCEvent {
     var type: String?
     var target: String?
     var clientDate: Date?
-    var value: Int?
+    var value: Double?
     var metaData: [String: Any]?
     
-    init (type: String?, target: String?, clientDate: Date?, value: Int?, metaData: [String: Any]?) {
+    init (type: String?, target: String?, clientDate: Date?, value: Double?, metaData: [String: Any]?) {
         self.type =  type
         self.target = target
         self.clientDate = clientDate
@@ -47,7 +47,7 @@ public class DVCEvent {
             return self
         }
         
-        public func value(_ value: Int) -> EventBuilder {
+        public func value(_ value: Double) -> EventBuilder {
             self.event.value = value
             return self
         }

--- a/DevCycle/ObjC/ObjCDVCEvent.swift
+++ b/DevCycle/ObjC/ObjCDVCEvent.swift
@@ -49,7 +49,7 @@ public class ObjCDVCEvent: NSObject {
             eventBuilder = eventBuilder.clientDate(eventDate as Date)
         }
         if let eventValue = self.value {
-            eventBuilder = eventBuilder.value(eventValue as! Int)
+            eventBuilder = eventBuilder.value(eventValue as! Double)
         }
         if let eventMetaData = self.metaData {
             eventBuilder = eventBuilder.metaData(eventMetaData as! [String : Any])

--- a/DevCycleTests/Models/DVCClientTest.swift
+++ b/DevCycleTests/Models/DVCClientTest.swift
@@ -92,6 +92,22 @@ class DVCClientTest: XCTestCase {
         wait(for: [expectation], timeout: 1.0)
     }
     
+    func testTrackWithValidDVCEventWithAllParamsDefinedAndDoubleValue() {
+        let expectation = XCTestExpectation(description: "EventQueue has one fully defined event")
+        let client = DVCClient()
+        let metaData: [String:Any] = ["test1": "key", "test2": 2, "test3": false]
+        let event: DVCEvent = try! DVCEvent.builder().type("test").target("test").clientDate(Date()).value(364.25).metaData(metaData).build()
+        
+        client.track(event)
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            XCTAssertTrue(client.eventQueue.events.count == 1)
+            expectation.fulfill()
+        }
+        
+        wait(for: [expectation], timeout: 1.0)
+    }
+    
     func testFlushEventsWithOneEventInQueue() {
         let expectation = XCTestExpectation(description: "EventQueue publishes an event")
         let options = DVCOptions.builder().disableEventLogging(false).flushEventsIntervalMs(10000).build()


### PR DESCRIPTION
- change `DVCEvent.value` from `Int` to `Double`