### PR TITLE
fix: percent encode + properly in query param

### DIFF
--- a/DevCycle/Networking/DevCycleService.swift
+++ b/DevCycle/Networking/DevCycleService.swift
@@ -214,7 +214,9 @@ class DevCycleService: DevCycleServiceProtocol {
                 userQueryItems.append(URLQueryItem(name: "sseLastModified", value: String(lastModified)))
             }
         }
-        let urlComponents: URLComponents = createRequestUrl(type: "config", userQueryItems)
+        var urlComponents: URLComponents = createRequestUrl(type: "config", userQueryItems)
+        urlComponents.percentEncodedQuery = urlComponents.percentEncodedQuery?
+            .replacingOccurrences(of: "+", with: "%2B")
         let url = urlComponents.url!
         return URLRequest(url: url)
     }


### PR DESCRIPTION
# Summary

Properly encode `+` in query params because Apple doesn't want to.