### PR TITLE
[feat] add model identifier for osx

### DIFF
--- a/DevCycle/Models/PlatformDetails.swift
+++ b/DevCycle/Models/PlatformDetails.swift
@@ -9,6 +9,8 @@ import Foundation
 
 #if os(iOS)
 import UIKit
+#elseif os(OSX)
+import IOKit
 #endif
 
 struct PlatformDetails {
@@ -19,11 +21,23 @@ struct PlatformDetails {
     #elseif os(OSX)
     
     // TODO: figure out how to get this from macos: https://stackoverflow.com/questions/20070333/obtain-model-identifier-string-on-os-x
-    var deviceModel = "model"
+    var deviceModel = getModelIdentifier()
     var systemVersion: String { ProcessInfo.processInfo.operatingSystemVersionString }
     var systemName = "macos"
     #endif
     
     var sdkType = "mobile"
     var sdkVersion = "1.7.2"
+}
+
+func getModelIdentifier() -> String? {
+    let service = IOServiceGetMatchingService(kIOMasterPortDefault,
+                                              IOServiceMatching("IOPlatformExpertDevice"))
+    var modelIdentifier: String?
+    if let modelData = IORegistryEntryCreateCFProperty(service, "model" as CFString, kCFAllocatorDefault, 0).takeRetainedValue() as? Data {
+        modelIdentifier = String(data: modelData, encoding: .utf8)?.trimmingCharacters(in: .controlCharacters)
+    }
+
+    IOObjectRelease(service)
+    return modelIdentifier
 }


### PR DESCRIPTION
ref: https://stackoverflow.com/questions/20070333/obtain-model-identifier-string-on-os-x

testing using the output here :
```
[DevCycle][debug][request] Request completed: https://sdk-api.devcycle.com/v1/mobileSDKConfig?user_id=CAED436D-A83A-471A-8E61-2EBBD661B626&isAnonymous=true&appVersion=1.0&appBuild=1&lastSeenDate=1673925186&createdDate=1673925186&platform=macos&platformVersion=Version%2013.0.1%20(Build%2022A400)&deviceModel=MacBookPro18,1&sdkType=mobile&sdkVersion=1.7.2&enableEdgeDB=false&envKey=dvc_mobile_6da261ea_09f4_4674_8383_82e48334a5e4_2f64c74, response time: 317.23594665527344 ms
```