### PR TITLE
fix: fix variable getting called from multiple threads causing a crash

### DIFF
--- a/DevCycle.xcodeproj/project.pbxproj
+++ b/DevCycle.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		52133B2228DE00BC0007691D /* ProcessConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52133B2128DE00BC0007691D /* ProcessConfig.swift */; };
 		52133B2428DE0FEB0007691D /* GetTestConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52133B2328DE0FEB0007691D /* GetTestConfig.swift */; };
 		5226DF06290C588900630745 /* NotificationNames.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5226DF05290C588900630745 /* NotificationNames.swift */; };
+		523A31D029CB411A008F3347 /* ThreadingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 523A31CF29CB411A008F3347 /* ThreadingTests.swift */; };
 		52404CEA27F3A9FB00290A31 /* isEqual.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52404CE927F3A9FB00290A31 /* isEqual.swift */; };
 		52404CED27F4A92100290A31 /* IsEqualTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52404CEC27F4A92100290A31 /* IsEqualTests.swift */; };
 		524D58242770F78B00D7CC56 /* ObjCDVCVariable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 524D58232770F78B00D7CC56 /* ObjCDVCVariable.swift */; };
@@ -85,6 +86,7 @@
 		52133B2128DE00BC0007691D /* ProcessConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessConfig.swift; sourceTree = "<group>"; };
 		52133B2328DE0FEB0007691D /* GetTestConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetTestConfig.swift; sourceTree = "<group>"; };
 		5226DF05290C588900630745 /* NotificationNames.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationNames.swift; sourceTree = "<group>"; };
+		523A31CF29CB411A008F3347 /* ThreadingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ThreadingTests.swift; path = DevCycleTests/Models/ThreadingTests.swift; sourceTree = SOURCE_ROOT; };
 		52404CE927F3A9FB00290A31 /* isEqual.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = isEqual.swift; sourceTree = "<group>"; };
 		52404CEC27F4A92100290A31 /* IsEqualTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IsEqualTests.swift; sourceTree = "<group>"; };
 		524D58232770F78B00D7CC56 /* ObjCDVCVariable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ObjCDVCVariable.swift; sourceTree = "<group>"; };
@@ -150,6 +152,7 @@
 		52133B1E28DDFAF90007691D /* Networking */ = {
 			isa = PBXGroup;
 			children = (
+				523A31CF29CB411A008F3347 /* ThreadingTests.swift */,
 				52E693F52758032500B52375 /* DevCycleServiceTests.swift */,
 			);
 			path = Networking;
@@ -456,6 +459,7 @@
 				52E693F62758032500B52375 /* DevCycleServiceTests.swift in Sources */,
 				52404CED27F4A92100290A31 /* IsEqualTests.swift in Sources */,
 				5268DB6B275020F800D17A40 /* DVCClientTest.swift in Sources */,
+				523A31D029CB411A008F3347 /* ThreadingTests.swift in Sources */,
 				529F0C90277374150075AAB4 /* ObjcDVCVariableTests.m in Sources */,
 				5268DB69275020D900D17A40 /* DVCUserTest.swift in Sources */,
 				52A1139F27AB235C000B8285 /* EventQueueTests.swift in Sources */,

--- a/DevCycleTests/Models/ThreadingTests.swift
+++ b/DevCycleTests/Models/ThreadingTests.swift
@@ -1,0 +1,51 @@
+//
+//  ThreadingTests.swift
+//  DevCycleTests
+//
+//  Copyright © 2023 Taplytics. All rights reserved.
+//
+
+import XCTest
+@testable import DevCycle
+
+final class ThreadingTests: XCTestCase {
+    private var service: MockService!
+    private var user: DVCUser!
+    private var builder: DVCClient.ClientBuilder!
+    private var userConfig: UserConfig!
+    
+    override func setUpWithError() throws {
+        self.service = MockService()
+        self.user = try! DVCUser.builder()
+                    .userId("my_user")
+                    .build()
+        self.builder = DVCClient.builder().service(service)
+
+        let data = getConfigData(name: "test_config")
+        let dictionary = try! JSONSerialization.jsonObject(with: data, options: .fragmentsAllowed) as! [String:Any]
+        self.userConfig = try! UserConfig(from: dictionary)
+    }
+
+    func testVariableWorksInASyncBlockOnMainThread() throws {
+        let client = try! self.builder.user(self.user).sdkKey("my_sdk_key").build(onInitialized: nil)
+        let expectation = expectation(description: "Expect calling variable in a sync block on the main thread doesn't crash")
+        DispatchQueue.global(qos: .userInitiated).async {
+            DispatchQueue.main.sync {
+                client.variable(key: "test-key", defaultValue: false)
+                expectation.fulfill()
+            }
+        }
+        wait(for: [expectation], timeout: 1.0)
+    }
+
+}
+
+private class MockService: DevCycleServiceProtocol {
+    func getConfig(user: DVCUser, enableEdgeDB: Bool, extraParams: RequestParams?, completion: @escaping ConfigCompletionHandler) {}
+    
+    func publishEvents(events: [DVCEvent], user: DVCUser, completion: @escaping PublishEventsCompletionHandler) {}
+    
+    func saveEntity(user: DVCUser, completion: @escaping SaveEntityCompletionHandler) {}
+    
+    func makeRequest(request: URLRequest, completion: @escaping DevCycle.CompletionHandler) {}
+}


### PR DESCRIPTION
# Summary

Added a separate queue to prevent crashes from accessing `variableInstanceDictionary` in separate threads.