### PR TITLE
switch all “public class” to “open class” to allow sub-classing

### DIFF
--- a/DevCycle/DVCClient.swift
+++ b/DevCycle/DVCClient.swift
@@ -28,7 +28,7 @@ public typealias IdentifyCompletedHandler = (Error?, [String: Variable]?) -> Voi
 public typealias FlushCompletedHandler = (Error?) -> Void
 public typealias CloseCompletedHandler = () -> Void
 
-public class DVCClient {
+open class DVCClient {
     var sdkKey: String?
     var user: DVCUser?
     var lastIdentifiedUser: DVCUser?
@@ -424,7 +424,7 @@ public class DVCClient {
         self.sseConnection?.close()
     }
     
-    public class ClientBuilder {
+    open class ClientBuilder {
         private var client: DVCClient
         private var service: DevCycleServiceProtocol?
 

--- a/DevCycle/DVCUser.swift
+++ b/DevCycle/DVCUser.swift
@@ -18,7 +18,7 @@ enum UserError: Error {
     case InvalidUser
 }
 
-public class UserBuilder {
+open class UserBuilder {
     private let cacheService: CacheServiceProtocol = CacheService()
     
     var user: DVCUser
@@ -113,7 +113,7 @@ public class UserBuilder {
 }
 
 
-public class DVCUser: Codable {
+open class DVCUser: Codable {
     public var userId: String?
     public var isAnonymous: Bool?
     public var email: String?

--- a/DevCycle/DVCVariable.swift
+++ b/DevCycle/DVCVariable.swift
@@ -9,7 +9,7 @@ import Foundation
 
 public typealias VariableValueHandler<T> = (T) -> Void
 
-public class DVCVariable<T> {
+open class DVCVariable<T> {
     public var key: String
     public var type: String
     public var handler: VariableValueHandler<T>?

--- a/DevCycle/Models/CustomData.swift
+++ b/DevCycle/Models/CustomData.swift
@@ -50,7 +50,7 @@ public enum CustomDataValue: Codable {
     }
 }
 
-public class CustomData: Codable {
+open class CustomData: Codable {
     public var data: [String: CustomDataValue]
     
     public static func customDataFromDic(_ data: [String: Any]) throws -> CustomData {

--- a/DevCycle/Models/DVCConfig.swift
+++ b/DevCycle/Models/DVCConfig.swift
@@ -6,7 +6,7 @@
 
 import Foundation
 
-public class DVCConfig {
+open class DVCConfig {
     var sdkKey: String
     var user: DVCUser
     var userConfig: UserConfig? {

--- a/DevCycle/Models/DVCEvent.swift
+++ b/DevCycle/Models/DVCEvent.swift
@@ -10,7 +10,7 @@ enum EventError: Error {
     case MissingEventType
 }
 
-public class DVCEvent {
+open class DVCEvent {
     var type: String?
     var target: String?
     var clientDate: Date?
@@ -25,7 +25,7 @@ public class DVCEvent {
         self.metaData = metaData
     }
     
-    public class EventBuilder {
+    open class EventBuilder {
         var event: DVCEvent
         
         init () {

--- a/DevCycle/Models/DVCOptions.swift
+++ b/DevCycle/Models/DVCOptions.swift
@@ -6,7 +6,7 @@
 
 import Foundation
 
-public class DVCOptions {
+open class DVCOptions {
     var flushEventsIntervalMs: Int?
     var disableEventLogging: Bool?
     var logLevel: LogLevel = .error
@@ -15,7 +15,7 @@ public class DVCOptions {
     var configCacheTTL: Int = 604800000
     var disableRealtimeUpdates: Bool = false
     
-    public class OptionsBuilder {
+    open class OptionsBuilder {
         var options: DVCOptions
         
         init () {


### PR DESCRIPTION
Using `public class` with our classes doesn't allow someone to sub-class any of our methods, switching to `open class` enables that. 

https://stackoverflow.com/questions/38979371/cannot-inherit-from-non-open-class-swift