### PR TITLE
feat: rename DevCycleOptions.flushEventsIntervalMs to eventFlushIntervalMS

### DIFF
--- a/DevCycle/DevCycleClient.swift
+++ b/DevCycle/DevCycleClient.swift
@@ -75,7 +75,7 @@ public class DevCycleClient {
     internal func initialize(service: DevCycleServiceProtocol, callback: ClientInitializedHandler?) {
         if let options = self.options {
             Log.level = options.logLevel
-            self.flushEventsInterval = Double(self.options?.flushEventsIntervalMs ?? self.defaultFlushInterval) / 1000.0
+            self.flushEventsInterval = Double(self.options?.eventFlushIntervalMS ?? self.defaultFlushInterval) / 1000.0
             self.enableEdgeDB = options.enableEdgeDB
             self.disableAutomaticEventLogging = options.disableAutomaticEventLogging
             self.disableCustomEventLogging = options.disableCustomEventLogging

--- a/DevCycle/Models/DevCycleOptions.swift
+++ b/DevCycle/Models/DevCycleOptions.swift
@@ -6,7 +6,7 @@
 import Foundation
 
 public class DevCycleOptions {
-    var flushEventsIntervalMs: Int?
+    var eventFlushIntervalMS: Int?
     var disableEventLogging: Bool?
     var logLevel: LogLevel = .error
     var enableEdgeDB: Bool = false
@@ -25,8 +25,14 @@ public class DevCycleOptions {
         }
         
         // Controls the interval between flushing events to the DevCycle servers in milliseconds, defaults to 10 seconds.
+        public func eventFlushIntervalMS(_ interval: Int? = 10000) -> OptionsBuilder {
+            self.options.eventFlushIntervalMS = interval
+            return self
+        }
+        
+        @available(*, deprecated, message: "Use eventFlushIntervalMS")
         public func flushEventsIntervalMs(_ interval: Int? = 10000) -> OptionsBuilder {
-            self.options.flushEventsIntervalMs = interval
+            self.options.eventFlushIntervalMS = interval
             return self
         }
         

--- a/DevCycle/ObjC/ObjCDevCycleOptions.swift
+++ b/DevCycle/ObjC/ObjCDevCycleOptions.swift
@@ -14,7 +14,9 @@ public class ObjCLogLevel: NSObject {
 
 @objc(DevCycleOptions)
 public class ObjCDevCycleOptions: NSObject {
+    @available(*, deprecated, message: "Use eventFlushIntervalMS")
     @objc public var flushEventsIntervalMs: NSNumber?
+    @objc public var eventFlushIntervalMS: NSNumber?
     @objc public var disableEventLogging: NSNumber?
     @objc public var logLevel: NSNumber?
     @objc public var enableEdgeDB: NSNumber?
@@ -27,9 +29,12 @@ public class ObjCDevCycleOptions: NSObject {
     
     func buildDevCycleOptions() -> DevCycleOptions {
         var optionsBuilder = DevCycleOptions.builder()
-        if let flushEventsIntervalMs = self.flushEventsIntervalMs,
-           let interval = flushEventsIntervalMs as? Int {
-            optionsBuilder = optionsBuilder.flushEventsIntervalMs(interval)
+        if let eventFlushIntervalMS = self.eventFlushIntervalMS,
+           let interval = eventFlushIntervalMS as? Int {
+            optionsBuilder = optionsBuilder.eventFlushIntervalMS(interval)
+        } else if let flushEventsIntervalMs = self.flushEventsIntervalMs,
+                  let interval = flushEventsIntervalMs as? Int {
+            optionsBuilder = optionsBuilder.eventFlushIntervalMS(interval)
         }
         
         if let disableEventLogging = self.disableEventLogging,

--- a/DevCycleTests/Models/DevCycleOptionsTest.swift
+++ b/DevCycleTests/Models/DevCycleOptionsTest.swift
@@ -10,13 +10,13 @@ class DevCycleOptionsTest: XCTestCase {
     func testOptionsAreNil() {
         let options = DevCycleOptions()
         XCTAssertNil(options.disableEventLogging)
-        XCTAssertNil(options.flushEventsIntervalMs)
+        XCTAssertNil(options.eventFlushIntervalMS)
     }
     
     func testBuilderReturnsOptions() {
         let options = DevCycleOptions.builder()
                 .disableEventLogging(false)
-                .flushEventsIntervalMs(1000)
+                .eventFlushIntervalMS(1000)
                 .enableEdgeDB(true)
                 .configCacheTTL(172800000)
                 .disableConfigCache(true)
@@ -26,7 +26,7 @@ class DevCycleOptionsTest: XCTestCase {
                 .apiProxyURL("localhost:4000")
                 .build()
         XCTAssertNotNil(options)
-        XCTAssert(options.flushEventsIntervalMs == 1000)
+        XCTAssert(options.eventFlushIntervalMS == 1000)
         XCTAssertFalse(options.disableEventLogging!)
         XCTAssert(options.enableEdgeDB)
         XCTAssert(options.configCacheTTL == 172800000)
@@ -42,7 +42,7 @@ class DevCycleOptionsTest: XCTestCase {
                 .disableEventLogging(false)
                 .build()
         XCTAssertNotNil(options)
-        XCTAssertNil(options.flushEventsIntervalMs)
+        XCTAssertNil(options.eventFlushIntervalMS)
         XCTAssertFalse(options.disableEventLogging!)
         XCTAssertFalse(options.enableEdgeDB)
         XCTAssertFalse(options.disableRealtimeUpdates)
@@ -51,9 +51,10 @@ class DevCycleOptionsTest: XCTestCase {
     func testDeprecatedDVCOptions() {
         let options = DVCOptions.builder()
                 .disableEventLogging(false)
+                .flushEventsIntervalMs(2000)
                 .build()
         XCTAssertNotNil(options)
-        XCTAssertNil(options.flushEventsIntervalMs)
+        XCTAssert(options.eventFlushIntervalMS == 2000)
         XCTAssertFalse(options.disableEventLogging!)
         XCTAssertFalse(options.enableEdgeDB)
         XCTAssertFalse(options.disableRealtimeUpdates)


### PR DESCRIPTION
- Rename `DevCycleOptions.flushEventsIntervalMs` to `eventFlushIntervalMS` to be consistent with other client SDKs. Mark `flushEventsIntervalMs` as deprecated.
