### PR TITLE
fix: switch DevCycleUser platform params to internal from public

### DIFF
--- a/DevCycle/DevCycleUser.swift
+++ b/DevCycle/DevCycleUser.swift
@@ -119,17 +119,18 @@ public class DevCycleUser: Codable {
     public var name: String?
     public var language: String?
     public var country: String?
-    public var appVersion: String?
-    public var appBuild: Int?
     public var customData: CustomData?
     public var privateCustomData: CustomData?
-    public var lastSeenDate: Date
-    public let createdDate: Date
-    public let platform: String
-    public let platformVersion: String
-    public let deviceModel: String
-    public let sdkType: String
-    public let sdkVersion: String
+    
+    internal var lastSeenDate: Date
+    internal let createdDate: Date
+    internal let platform: String
+    internal let platformVersion: String
+    internal let deviceModel: String
+    internal let sdkType: String
+    internal let sdkVersion: String
+    internal var appVersion: String?
+    internal var appBuild: Int?
     
     init() {
         let platform = PlatformDetails()


### PR DESCRIPTION
difference between internal and public: https://medium.com/hash-coding/swift-access-control-ios-dab45a0b79ab#:~:text=Public%20%E2%80%94%20This%20is%20the%20same,outside%20the%20module(target).