### PR TITLE
feat: update variable interface to known supported types

### DIFF
--- a/DevCycle/DevCycleClient.swift
+++ b/DevCycle/DevCycleClient.swift
@@ -263,17 +263,53 @@ public class DevCycleClient {
         })
     }
     
-    public func variableValue<T>(key: String, defaultValue: T) -> T {
-        return variable(key: key, defaultValue: defaultValue).value
+    public func variableValue(key: String, defaultValue: Bool) -> Bool {
+        return getVariable(key: key, defaultValue: defaultValue).value
+    }
+    public func variableValue(key: String, defaultValue: String) -> String {
+        return getVariable(key: key, defaultValue: defaultValue).value
+    }
+    public func variableValue(key: String, defaultValue: NSString) -> NSString {
+        return getVariable(key: key, defaultValue: defaultValue).value
+    }
+    public func variableValue(key: String, defaultValue: Double) -> Double {
+        return getVariable(key: key, defaultValue: defaultValue).value
+    }
+    public func variableValue(key: String, defaultValue: NSNumber) -> NSNumber {
+        return getVariable(key: key, defaultValue: defaultValue).value
+    }
+    public func variableValue(key: String, defaultValue: NSDictionary) -> NSDictionary {
+        return getVariable(key: key, defaultValue: defaultValue).value
+    }
+    
+    public func variable(key: String, defaultValue: Bool) -> DVCVariable<Bool> {
+        return getVariable(key: key, defaultValue: defaultValue)
+    }
+    public func variable(key: String, defaultValue: String) -> DVCVariable<String> {
+        return getVariable(key: key, defaultValue: defaultValue)
+    }
+    public func variable(key: String, defaultValue: NSString) -> DVCVariable<NSString> {
+        return getVariable(key: key, defaultValue: defaultValue)
+    }
+    public func variable(key: String, defaultValue: Double) -> DVCVariable<Double> {
+        return getVariable(key: key, defaultValue: defaultValue)
+    }
+    public func variable(key: String, defaultValue: NSNumber) -> DVCVariable<NSNumber> {
+        return getVariable(key: key, defaultValue: defaultValue)
+    }
+    public func variable(key: String, defaultValue: Dictionary<String, Any>) -> DVCVariable<Dictionary<String, Any>> {
+        return getVariable(key: key, defaultValue: defaultValue)
+    }
+    public func variable(key: String, defaultValue: NSDictionary) -> DVCVariable<NSDictionary> {
+        return getVariable(key: key, defaultValue: defaultValue)
     }
 
-    public func variable<T>(key: String, defaultValue: T) -> DVCVariable<T> {
+    func getVariable<T>(key: String, defaultValue: T) -> DVCVariable<T> {
         let regex = try? NSRegularExpression(pattern: ".*[^a-z0-9(\\-)(_)].*")
         if (regex?.firstMatch(in: key, range: NSMakeRange(0, key.count)) != nil) {
             Log.error("The variable key \(key) is invalid. It must contain only lowercase letters, numbers, hyphens and underscores. The default value will always be returned for this call.")
             return DVCVariable(
                 key: key,
-                type: String(describing: T.self),
                 value: nil,
                 defaultValue: defaultValue,
                 evalReason: nil
@@ -285,6 +321,7 @@ public class DevCycleClient {
             if (self.variableInstanceDictonary[key] == nil) {
                 self.variableInstanceDictonary[key] = NSMapTable<AnyObject, AnyObject>(valueOptions: .weakMemory)
             }
+            
             if let variableFromDictionary = self.variableInstanceDictonary[key]?.object(forKey: defaultValue as AnyObject) as? DVCVariable<T> {
                 variable = variableFromDictionary
             } else {
@@ -294,19 +331,17 @@ public class DevCycleClient {
                 } else {
                     variable = DVCVariable(
                         key: key,
-                        type: String(describing: T.self),
                         value: nil,
                         defaultValue: defaultValue,
                         evalReason: nil
                     )
                 }
-                    self.variableInstanceDictonary[key]?.setObject(variable, forKey: defaultValue as AnyObject)
+                
+                self.variableInstanceDictonary[key]?.setObject(variable, forKey: defaultValue as AnyObject)
             }
             
-            if (!self.closed) {
-                if(!self.disableAutomaticEventLogging){
-                    self.eventQueue.updateAggregateEvents(variableKey: variable.key, variableIsDefaulted: variable.isDefaulted)
-                }
+            if (!self.closed && !self.disableAutomaticEventLogging) {
+                self.eventQueue.updateAggregateEvents(variableKey: variable.key, variableIsDefaulted: variable.isDefaulted)
             }
             
             return variable

--- a/DevCycle/DevCycleClient.swift
+++ b/DevCycle/DevCycleClient.swift
@@ -278,6 +278,9 @@ public class DevCycleClient {
     public func variableValue(key: String, defaultValue: NSNumber) -> NSNumber {
         return getVariable(key: key, defaultValue: defaultValue).value
     }
+    public func variableValue(key: String, defaultValue: Dictionary<String, Any>) -> Dictionary<String, Any> {
+        return getVariable(key: key, defaultValue: defaultValue).value
+    }
     public func variableValue(key: String, defaultValue: NSDictionary) -> NSDictionary {
         return getVariable(key: key, defaultValue: defaultValue).value
     }

--- a/DevCycle/Models/UserConfig.swift
+++ b/DevCycle/Models/UserConfig.swift
@@ -9,6 +9,7 @@ import Foundation
 enum UserConfigError: Error {
     case MissingInConfig(String)
     case MissingProperty(String)
+    case InvalidVariableType(String)
 }
 
 public struct UserConfig {
@@ -152,18 +153,27 @@ public struct Feature {
 public struct Variable {
     public var _id: String
     public var key: String
-    public var type: String
+    public var type: DVCVariableTypes
     public var value: Any
     public var evalReason: String?
     
     init (from dictionary: [String: Any]) throws {
-        guard let id = dictionary["_id"] as? String else { throw UserConfigError.MissingProperty("_id in Variable object") }
-        guard let key = dictionary["key"] as? String else { throw UserConfigError.MissingProperty("key in Variable object") }
-        guard let type = dictionary["type"] as? String else { throw UserConfigError.MissingProperty("type in Variable object") }
+        guard let id = dictionary["_id"] as? String else {
+            throw UserConfigError.MissingProperty("_id in Variable object")
+        }
+        guard let key = dictionary["key"] as? String else {
+            throw UserConfigError.MissingProperty("key in Variable object")
+        }
+        guard let type = dictionary["type"] as? String else {
+            throw UserConfigError.MissingProperty("type in Variable object")
+        }
+        guard let varType = DVCVariableTypes(rawValue: type) else {
+            throw UserConfigError.InvalidVariableType("invalid Variable type: \(type)")
+        }
         guard let value = dictionary["value"] else { throw UserConfigError.MissingProperty("value in Variable object") }
         self._id = id
         self.key = key
-        self.type = type
+        self.type = varType
         self.evalReason = dictionary["evalReason"] as? String
         
         if (type == "Boolean") {

--- a/DevCycle/ObjC/ObjCDVCVariable.swift
+++ b/DevCycle/ObjC/ObjCDVCVariable.swift
@@ -24,7 +24,7 @@ public class ObjCDVCVariable: NSObject {
     init<T>(_ dvcVariable: DVCVariable<T>) {
         self.dvcVariable = dvcVariable
         self.key = dvcVariable.key
-        self.type = dvcVariable.type
+        self.type = dvcVariable.type?.rawValue
         self.evalReason = dvcVariable.evalReason
         self.isDefaulted = dvcVariable.isDefaulted
         self.value = dvcVariable.value
@@ -41,7 +41,7 @@ public class ObjCDVCVariable: NSObject {
     
     func setValues<T>(dvcVariable: DVCVariable<T>) {
         self.key = dvcVariable.key
-        self.type = dvcVariable.type
+        self.type = dvcVariable.type?.rawValue
         self.evalReason = dvcVariable.evalReason
         self.isDefaulted = dvcVariable.isDefaulted
         self.value = dvcVariable.value

--- a/DevCycle/ObjC/ObjCDevCycleClient.swift
+++ b/DevCycle/ObjC/ObjCDevCycleClient.swift
@@ -133,58 +133,64 @@ public class ObjCDevCycleClient: NSObject {
     }
     
     @objc public func stringVariableValue(key: String, defaultValue: String) -> String {
-        return variableValue(key: key, defaultValue: defaultValue)
-    }
-    
-    @objc public func numberVariableValue(key: String, defaultValue: NSNumber) -> NSNumber {
-        return variableValue(key: key, defaultValue: defaultValue)
-    }
-    
-    @objc public func boolVariableValue(key: String, defaultValue: Bool) -> Bool {
-        return variableValue(key: key, defaultValue: defaultValue)
-    }
-    
-    @objc public func jsonVariableValue(key: String, defaultValue: NSObject) -> NSObject {
-        return variableValue(key: key, defaultValue: defaultValue)
-    }
-    
-    @objc public func stringVariable(key: String, defaultValue: String) -> ObjCDVCVariable {
-        return variable(key: key, defaultValue: defaultValue)
-    }
-    
-    @objc public func numberVariable(key: String, defaultValue: NSNumber) -> ObjCDVCVariable {
-        return variable(key: key, defaultValue: defaultValue)
-    }
-    
-    @objc public func boolVariable(key: String, defaultValue: Bool) -> ObjCDVCVariable {
-        return variable(key: key, defaultValue: defaultValue)
-    }
-    
-    @objc public func jsonVariable(key: String, defaultValue: NSObject) -> ObjCDVCVariable {
-        return variable(key: key, defaultValue: defaultValue)
-    }
-    
-    func variableValue<T>(key: String, defaultValue: T) -> T {
         guard let client = self.client else {
             return defaultValue
         }
-        return client.variable(key: key, defaultValue: defaultValue).value
+        return client.variableValue(key: key, defaultValue: defaultValue)
+    }
+    @objc public func numberVariableValue(key: String, defaultValue: NSNumber) -> NSNumber {
+        guard let client = self.client else {
+            return defaultValue
+        }
+        return client.variableValue(key: key, defaultValue: defaultValue)
+    }
+    @objc public func boolVariableValue(key: String, defaultValue: Bool) -> Bool {
+        guard let client = self.client else {
+            return defaultValue
+        }
+        return client.variableValue(key: key, defaultValue: defaultValue)
+    }
+    @objc public func jsonVariableValue(key: String, defaultValue: NSDictionary) -> NSDictionary {
+        guard let client = self.client else {
+            return defaultValue
+        }
+        return client.variableValue(key: key, defaultValue: defaultValue)
     }
     
-    func variable<T>(key: String, defaultValue: T) -> ObjCDVCVariable {
+    @objc public func stringVariable(key: String, defaultValue: String) -> ObjCDVCVariable {
         guard let client = self.client else {
-            return ObjCDVCVariable(
-                DVCVariable<T>(
-                    key: key,
-                    type: String(describing: T.self),
-                    value: nil,
-                    defaultValue: defaultValue,
-                    evalReason: nil
-                )
-            )
+            return objcDefaultVariable(key: key, defaultValue: defaultValue)
         }
-
         return ObjCDVCVariable(client.variable(key: key, defaultValue: defaultValue))
+    }
+    @objc public func numberVariable(key: String, defaultValue: NSNumber) -> ObjCDVCVariable {
+        guard let client = self.client else {
+            return objcDefaultVariable(key: key, defaultValue: defaultValue)
+        }
+        return ObjCDVCVariable(client.variable(key: key, defaultValue: defaultValue))
+    }
+    @objc public func boolVariable(key: String, defaultValue: Bool) -> ObjCDVCVariable {
+        guard let client = self.client else {
+            return objcDefaultVariable(key: key, defaultValue: defaultValue)
+        }
+        return ObjCDVCVariable(client.variable(key: key, defaultValue: defaultValue))
+    }
+    @objc public func jsonVariable(key: String, defaultValue: NSDictionary) -> ObjCDVCVariable {
+        guard let client = self.client else {
+            return objcDefaultVariable(key: key, defaultValue: defaultValue)
+        }
+        return ObjCDVCVariable(client.variable(key: key, defaultValue: defaultValue))
+    }
+    
+    func objcDefaultVariable<T>(key: String, defaultValue: T) -> ObjCDVCVariable {
+        return ObjCDVCVariable(
+            DVCVariable<T>(
+                key: key,
+                value: nil,
+                defaultValue: defaultValue,
+                evalReason: nil
+            )
+        )
     }
     
     @objc public func allFeatures() -> [String: ObjCFeature]? {

--- a/DevCycle/ObjC/ObjCUserConfig.swift
+++ b/DevCycle/ObjC/ObjCUserConfig.swift
@@ -42,7 +42,7 @@ public class ObjCVariable: NSObject {
     init(_ variable: Variable) {
         self._id = variable._id
         self.key = variable.key
-        self.type = variable.type
+        self.type = variable.type.rawValue
         self.value = variable.value
         self.evalReason = variable.evalReason
     }

--- a/DevCycleTests/Models/DevCycleClientTests.swift
+++ b/DevCycleTests/Models/DevCycleClientTests.swift
@@ -250,10 +250,15 @@ class DevCycleClientTest: XCTestCase {
         client.initialize(callback: nil)
         
         let variable = client.variable(key: "some_non_existent_variable", defaultValue: "string")
-        XCTAssert(variable.value == "string")
+        XCTAssertEqual(variable.value, "string")
         XCTAssert(variable.isDefaulted)
-        XCTAssert(variable.defaultValue == "string")
-        XCTAssert(variable.type == "String")
+        XCTAssertEqual(variable.defaultValue, "string")
+        XCTAssertEqual(variable.type, DVCVariableTypes.String)
+        
+        let nsString: NSString = "nsString"
+        let varNSString = client.variable(key: "some_non_existent_variable", defaultValue: nsString)
+        XCTAssertEqual(varNSString.defaultValue, nsString)
+        XCTAssertEqual(varNSString.type, DVCVariableTypes.String)
     }
     
     func testVariableBooleanDefaultValue() {
@@ -265,7 +270,7 @@ class DevCycleClientTest: XCTestCase {
         XCTAssertEqual(variable.value, true)
         XCTAssert(variable.isDefaulted)
         XCTAssertEqual(variable.defaultValue, true)
-        XCTAssertEqual(variable.type, "Boolean")
+        XCTAssertEqual(variable.type, DVCVariableTypes.Boolean)
     }
     
     func testVariableNumberDefaultValue() {
@@ -273,11 +278,17 @@ class DevCycleClientTest: XCTestCase {
         client.config?.userConfig = self.userConfig
         client.initialize(callback: nil)
         
-        let variable = client.variable(key: "some_non_existent_variable", defaultValue: 10.1)
-        XCTAssertEqual(variable.value, 10.1)
+        let double: Double = 10.1
+        let variable = client.variable(key: "some_non_existent_variable", defaultValue: double)
+        XCTAssertEqual(variable.value, double)
         XCTAssert(variable.isDefaulted)
-        XCTAssertEqual(variable.defaultValue, 10.1)
-        XCTAssertEqual(variable.type, "Number")
+        XCTAssertEqual(variable.defaultValue, double)
+        XCTAssertEqual(variable.type, DVCVariableTypes.Number)
+        
+        let nsNum: NSNumber = 10.1
+        let variableNum = client.variable(key: "some_non_existent_variable", defaultValue: nsNum)
+        XCTAssertEqual(variableNum.defaultValue, nsNum)
+        XCTAssertEqual(variableNum.type, DVCVariableTypes.Number)
     }
     
     func testVariableJSONDefaultValue() {
@@ -285,12 +296,18 @@ class DevCycleClientTest: XCTestCase {
         client.config?.userConfig = self.userConfig
         client.initialize(callback: nil)
         
-        let defaultVal = ["key":"val"]
+        let defaultVal: Dictionary<String, Any> = ["key":"val"]
         let variable = client.variable(key: "some_non_existent_variable", defaultValue: defaultVal)
-        XCTAssertEqual(variable.value, defaultVal)
+        XCTAssertEqual(variable.value.keys, defaultVal.keys)
+        XCTAssertEqual(variable.value["key"] as! String, defaultVal["key"] as! String)
         XCTAssert(variable.isDefaulted)
-        XCTAssertEqual(variable.defaultValue, defaultVal)
-        XCTAssertEqual(variable.type, "JSON")
+        XCTAssertEqual(variable.defaultValue["key"] as! String, defaultVal["key"] as! String)
+        XCTAssertEqual(variable.type, DVCVariableTypes.JSON)
+        
+        let nsDicDefault: NSDictionary = ["key":"val"]
+        let variable2 = client.variable(key: "some_non_existent_variable", defaultValue: nsDicDefault)
+        XCTAssertEqual(variable2.defaultValue, nsDicDefault)
+        XCTAssertEqual(variable2.type, DVCVariableTypes.JSON)        
     }
 
     func testVariableMethodReturnsCorrectVariableForKey() {
@@ -303,9 +320,9 @@ class DevCycleClientTest: XCTestCase {
         let boolValue = client.variableValue(key: "bool-var", defaultValue: false)
         XCTAssertTrue(boolValue)
 
-        let numVar = client.variable(key: "num-var", defaultValue: 0)
+        let numVar = client.variable(key: "num-var", defaultValue: 0.0)
         XCTAssertEqual(numVar.value, 4)
-        let numValue = client.variableValue(key: "num-var", defaultValue: 0)
+        let numValue = client.variableValue(key: "num-var", defaultValue: 0.0)
         XCTAssertEqual(numValue, 4)
 
         let stringVar = client.variable(key: "string-var", defaultValue: "default-string")
@@ -331,8 +348,8 @@ class DevCycleClientTest: XCTestCase {
         let boolVar = client.variable(key: "bool-var", defaultValue: false)
         XCTAssert(client.variable(key: "bool-var", defaultValue: false) === boolVar)
 
-        let numVar = client.variable(key: "num-var", defaultValue: 0)
-        XCTAssert(client.variable(key: "num-var", defaultValue: 0) === numVar)
+        let numVar = client.variable(key: "num-var", defaultValue: 0.0)
+        XCTAssert(client.variable(key: "num-var", defaultValue: 0.0) === numVar)
 
         let stringVar = client.variable(key: "string-var", defaultValue: "default-string")
         XCTAssert(client.variable(key: "string-var", defaultValue: "default-string") === stringVar)

--- a/DevCycleTests/Models/DevCycleClientTests.swift
+++ b/DevCycleTests/Models/DevCycleClientTests.swift
@@ -243,6 +243,55 @@ class DevCycleClientTest: XCTestCase {
         XCTAssertFalse(variableValue)
         client.close(callback: nil)
     }
+    
+    func testVariableStringDefaultValue() {
+        let client = try! self.builder.user(self.user).sdkKey("my_sdk_key").build(onInitialized: nil)
+        client.config?.userConfig = self.userConfig
+        client.initialize(callback: nil)
+        
+        let variable = client.variable(key: "some_non_existent_variable", defaultValue: "string")
+        XCTAssert(variable.value == "string")
+        XCTAssert(variable.isDefaulted)
+        XCTAssert(variable.defaultValue == "string")
+        XCTAssert(variable.type == "String")
+    }
+    
+    func testVariableBooleanDefaultValue() {
+        let client = try! self.builder.user(self.user).sdkKey("my_sdk_key").build(onInitialized: nil)
+        client.config?.userConfig = self.userConfig
+        client.initialize(callback: nil)
+        
+        let variable = client.variable(key: "some_non_existent_variable", defaultValue: true)
+        XCTAssertEqual(variable.value, true)
+        XCTAssert(variable.isDefaulted)
+        XCTAssertEqual(variable.defaultValue, true)
+        XCTAssertEqual(variable.type, "Boolean")
+    }
+    
+    func testVariableNumberDefaultValue() {
+        let client = try! self.builder.user(self.user).sdkKey("my_sdk_key").build(onInitialized: nil)
+        client.config?.userConfig = self.userConfig
+        client.initialize(callback: nil)
+        
+        let variable = client.variable(key: "some_non_existent_variable", defaultValue: 10.1)
+        XCTAssertEqual(variable.value, 10.1)
+        XCTAssert(variable.isDefaulted)
+        XCTAssertEqual(variable.defaultValue, 10.1)
+        XCTAssertEqual(variable.type, "Number")
+    }
+    
+    func testVariableJSONDefaultValue() {
+        let client = try! self.builder.user(self.user).sdkKey("my_sdk_key").build(onInitialized: nil)
+        client.config?.userConfig = self.userConfig
+        client.initialize(callback: nil)
+        
+        let defaultVal = ["key":"val"]
+        let variable = client.variable(key: "some_non_existent_variable", defaultValue: defaultVal)
+        XCTAssertEqual(variable.value, defaultVal)
+        XCTAssert(variable.isDefaulted)
+        XCTAssertEqual(variable.defaultValue, defaultVal)
+        XCTAssertEqual(variable.type, "JSON")
+    }
 
     func testVariableMethodReturnsCorrectVariableForKey() {
         let client = try! self.builder.user(self.user).sdkKey("my_sdk_key").build(onInitialized: nil)

--- a/DevCycleTests/Models/UserConfigTests.swift
+++ b/DevCycleTests/Models/UserConfigTests.swift
@@ -72,7 +72,7 @@ class UserConfigTests: XCTestCase {
         let config = try UserConfig(from: dictionary)
         let variable = config.variables["bool-var"]
         XCTAssert(variable?.key == "bool-var")
-        XCTAssert(variable?.type == "Boolean")
+        XCTAssertEqual(variable?.type, DVCVariableTypes.Boolean)
         XCTAssert((variable?.value as! Bool))
     }
     
@@ -82,7 +82,7 @@ class UserConfigTests: XCTestCase {
         let config = try UserConfig(from: dictionary)
         let variable = config.variables["string-var"]
         XCTAssert(variable?.key == "string-var")
-        XCTAssert(variable?.type == "String")
+        XCTAssertEqual(variable?.type, DVCVariableTypes.String)
         XCTAssert((variable?.value as! String) == "string1")
     }
     
@@ -92,7 +92,7 @@ class UserConfigTests: XCTestCase {
         let config = try UserConfig(from: dictionary)
         let variable = config.variables["num-var"]
         XCTAssert(variable?.key == "num-var")
-        XCTAssert(variable?.type == "Number")
+        XCTAssertEqual(variable?.type, DVCVariableTypes.Number)
         XCTAssert((variable?.value as! Double) == 4)
     }
     
@@ -104,7 +104,7 @@ class UserConfigTests: XCTestCase {
         let json = (variable?.value as! [String: Any])
         let nestedJson = json["key2"]
         XCTAssert(variable?.key == "json-var")
-        XCTAssert(variable?.type == "JSON")
+        XCTAssertEqual(variable?.type, DVCVariableTypes.JSON)
         XCTAssertNotNil(json)
         XCTAssertNotNil(nestedJson)
     }

--- a/DevCycleTests/ObjC/ObjCDevCycleClientTests.m
+++ b/DevCycleTests/ObjC/ObjCDevCycleClientTests.m
@@ -59,7 +59,7 @@
 
 #pragma mark - Variable Tests
 
-- (void)testVariableIsCreated {
+- (void)testVariableIsDefaulted {
     DevCycleUser *user = [DevCycleUser initializeWithUserId:@"my_user"];
     DevCycleClient *client = [DevCycleClient initialize:@"my_sdk_key" user:user options:nil onInitialized:nil];
     XCTAssertNotNil(client);
@@ -70,8 +70,8 @@
     XCTAssertEqual(variable.value, @"default-value");
     XCTAssertEqual(variable.defaultValue, @"default-value");
 }
-
-- (void)testVariableValueIsCreated {
+// TODO: these should all be non-deafulted
+- (void)testVariableValueStringDefault {
     DevCycleUser *user = [DevCycleUser initializeWithUserId:@"my_user"];
     DevCycleClient *client = [DevCycleClient initialize:@"my_sdk_key" user:user options:nil onInitialized:nil];
     XCTAssertNotNil(client);
@@ -80,12 +80,30 @@
     XCTAssertEqual(variableValue, @"default-value");
 }
 
-- (void)testVariableValueBool {
+- (void)testVariableValueBoolDefault {
     DevCycleUser *user = [DevCycleUser initializeWithUserId:@"my_user"];
     DevCycleClient *client = [DevCycleClient initialize:@"my_sdk_key" user:user options:nil onInitialized:nil];
     XCTAssertNotNil(client);
     BOOL boolValue = [client boolVariableValueWithKey:@"my-key" defaultValue:true];
     XCTAssertTrue(boolValue);
+}
+
+- (void)testVariableValueNumberDefault {
+    DevCycleUser *user = [DevCycleUser initializeWithUserId:@"my_user"];
+    DevCycleClient *client = [DevCycleClient initialize:@"my_sdk_key" user:user options:nil onInitialized:nil];
+    XCTAssertNotNil(client);
+    NSNumber *numDefault = @610.1;
+    NSNumber *numVal = [client numberVariableValueWithKey:@"my-key" defaultValue:numDefault];
+    XCTAssertEqual(numVal, numDefault);
+}
+
+- (void)testVariableValueJSONDefault {
+    DevCycleUser *user = [DevCycleUser initializeWithUserId:@"my_user"];
+    DevCycleClient *client = [DevCycleClient initialize:@"my_sdk_key" user:user options:nil onInitialized:nil];
+    XCTAssertNotNil(client);
+    NSDictionary *defaultDic = @{@"key": @"value", @"num": @610};
+    NSDictionary *jsonVal = [client jsonVariableValueWithKey:@"my-key" defaultValue:defaultDic];
+    XCTAssertEqual(jsonVal, defaultDic);
 }
 
 @end

--- a/DevCycleTests/ObjC/ObjcDVCVariableTests.m
+++ b/DevCycleTests/ObjC/ObjcDVCVariableTests.m
@@ -14,14 +14,51 @@
 
 @implementation ObjcDVCVariableTests
 
-- (void)testVariableGetsCreatedWithDefault {
+- (void)testStringVariableGetsCreatedWithDefault {
     DevCycleUser *user = [DevCycleUser initializeWithUserId:@"my_user"];
     DevCycleClient *client = [DevCycleClient initialize:@"key" user:user];
     DVCVariable *variable = [client stringVariableWithKey:@"my-key" defaultValue:@"my-default"];
     XCTAssertNotNil(variable);
     XCTAssertEqual(variable.value, @"my-default");
     XCTAssertEqual(variable.defaultValue, @"my-default");
-    XCTAssertNil(variable.evalReason);
+    XCTAssertTrue(variable.isDefaulted);
+}
+
+- (void)testBoolVariableGetsCreatedWithDefault {
+    DevCycleUser *user = [DevCycleUser initializeWithUserId:@"my_user"];
+    DevCycleClient *client = [DevCycleClient initialize:@"key" user:user];
+    DVCVariable *variable = [client boolVariableWithKey:@"my-key" defaultValue:false];
+    XCTAssertNotNil(variable);
+    NSNumber *boolValue = variable.value;
+    XCTAssertEqual(boolValue.boolValue, false);
+    NSNumber *defaultBoolValue = variable.defaultValue;
+    XCTAssertEqual(defaultBoolValue.boolValue, false);
+    XCTAssertTrue(variable.isDefaulted);
+    
+    bool varValue = [client boolVariableValueWithKey:@"my-key" defaultValue:false];
+    XCTAssertFalse(varValue);
+}
+
+- (void)testNumberVariableGetsCreatedWithDefault {
+    DevCycleUser *user = [DevCycleUser initializeWithUserId:@"my_user"];
+    DevCycleClient *client = [DevCycleClient initialize:@"key" user:user];
+    NSNumber* defaultNum = @610.1;
+    DVCVariable *variable = [client numberVariableWithKey:@"my-key" defaultValue:defaultNum];
+    XCTAssertNotNil(variable);
+    XCTAssert([variable.value isEqual:defaultNum]);
+    XCTAssert([variable.defaultValue isEqual:defaultNum]);
+    XCTAssertTrue(variable.isDefaulted);
+}
+
+- (void)testJSONVariableGetsCreatedWithDefault {
+    DevCycleUser *user = [DevCycleUser initializeWithUserId:@"my_user"];
+    DevCycleClient *client = [DevCycleClient initialize:@"key" user:user];
+    NSDictionary *defaultDic = @{@"key": @"value", @"num": @610};
+    DVCVariable *variable = [client jsonVariableWithKey:@"my-key" defaultValue:defaultDic];
+    XCTAssertNotNil(variable);
+    XCTAssertEqual(variable.value, defaultDic);
+    XCTAssertEqual(variable.defaultValue, defaultDic);
+    XCTAssertTrue(variable.isDefaulted);
 }
 
 @end


### PR DESCRIPTION
To resolve issues where the generic type of a `DVCVariable` could be different depending on if the default value or bucketed value was used, these changes were needed: 
- locking down the iOS SDK Swift interface for `variable()` and `variableValue()` to only support known supported types: `String` \ `Boolean` \ `Double` \ `NSNumber` \ `Dictionary` \ `NSDictionary`.
- added `DVCVariableTypes` enum to explicitly mark the variable type.
- Updated tests to support these changes