### PR TITLE
chore: update release workflows to trigger CocoaPod Publish workflow on new tag push

### DIFF
--- a/.github/workflows/ios.yaml
+++ b/.github/workflows/ios.yaml
@@ -2,7 +2,7 @@ name: Build and Test iOS
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   build:
@@ -10,14 +10,15 @@ jobs:
     steps:
       - name: Checkout Project
         uses: actions/checkout@v4
-      - name: "Select Latest Xcode"
+      - name: 'Select Latest Xcode'
         uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: latest-stable
-      - name: "Carthage Cached Bootstrap"
+      - name: 'Carthage Cached Bootstrap'
         uses: DevCycleHQ/carthage-bootstrap@xcframeworks2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           use-xcframeworks: true
       - name: Fastlane iOS Tests
         run: fastlane ios tests
+

--- a/.github/workflows/publish-pod.yml
+++ b/.github/workflows/publish-pod.yml
@@ -1,0 +1,31 @@
+name: CocoaPods Publish
+
+on:
+  push:
+    tags:
+      - v*.*.**
+    workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  publish-cocoapods:
+    needs: release
+    runs-on: macos-12
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.AUTOMATION_USER_TOKEN }}
+          fetch-depth: 0
+
+      - name: Fix WatchOS Simulators
+        run: |
+          ./scripts/fix_watchos_simulators.sh
+
+      - name: Publish to CocoaPods
+        env:
+          COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
+        run: |
+          pod trunk push DevCycle.podspec --allow-warnings --verbose
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,15 +1,15 @@
-name: Release
+name: Create Release Tag
 
 on:
   workflow_dispatch:
     inputs:
       prerelease:
-        description: "Prerelease"
+        description: 'Prerelease'
         required: true
         default: false
         type: boolean
       draft:
-        description: "Draft"
+        description: 'Draft'
         required: true
         default: false
         type: boolean
@@ -29,7 +29,6 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
-
     steps:
       # Check out the repo with credentials that can bypass branch protection, and fetch git history instead of just latest commit
       - uses: actions/checkout@v4
@@ -81,21 +80,3 @@ jobs:
           echo "::notice title=Release ID::${{ steps.create-release.outputs.release-id }}"
           echo "::notice title=Release URL::${{ steps.create-release.outputs.release-url }}"
 
-  publish-cocoapods:
-    needs: release
-    runs-on: macos-12
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.AUTOMATION_USER_TOKEN }}
-          fetch-depth: 0
-
-      - name: Fix WatchOS Simulators
-        run: |
-          ./scripts/fix_watchos_simulators.sh
-
-      - name: Publish to CocoaPods
-        env:
-          COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
-        run: |
-          pod trunk push DevCycle.podspec --allow-warnings --verbose

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,12 +1,5 @@
 #!/bin/bash
 SHA="$(git rev-parse HEAD)"
-DEVCYCLE_PROD_SLEUTH_API_TOKEN="$(aws secretsmanager get-secret-value --secret-id=DEVCYCLE_PROD_SLEUTH_API_TOKEN | jq -r .SecretString )"
-
-# make sure we're able to track this deployment
-if [[ -z "$DEVCYCLE_PROD_SLEUTH_API_TOKEN" ]]; then
-    echo "Sleuth.io deployment tracking token not found. Aborting."
-    exit 1
-fi
 
 # fix watchOS simulators: https://github.com/CocoaPods/CocoaPods/issues/11558#issuecomment-1284573492
 echo "Fixing watchOS Simulators"
@@ -29,8 +22,3 @@ if [[ "$?" != 0 ]]; then
     echo "Publish failed. Aborting."
     exit 1
 fi
-
-curl -X POST \
-    -d api_key=$DEVCYCLE_PROD_SLEUTH_API_TOKEN \
-    -d environment=production \
-    -d sha=$SHA https://app.sleuth.io/api/1/deployments/taplytics/ios-client-sdk/register_deploy


### PR DESCRIPTION
- update deploy script to remove unused sleuth call
- adds new publish-pod workflow that triggers on Tag pushes on main to publish the DevCycle pod to CocoaPod
- remove publish-cocoapods step from release workflow
