### PR TITLE
fix: re-add deprecated generic variable() and variableValue() methods

### DIFF
--- a/DevCycle/DevCycleClient.swift
+++ b/DevCycle/DevCycleClient.swift
@@ -284,6 +284,10 @@ public class DevCycleClient {
     public func variableValue(key: String, defaultValue: NSDictionary) -> NSDictionary {
         return getVariable(key: key, defaultValue: defaultValue).value
     }
+    @available(*, deprecated, renamed: "variableValue()", message: "Use strictly typed versions of variableValue() methods")
+    public func variableValue<T>(key: String, defaultValue: T) -> T {
+        return getVariable(key: key, defaultValue: defaultValue).value
+    }
     
     public func variable(key: String, defaultValue: Bool) -> DVCVariable<Bool> {
         return getVariable(key: key, defaultValue: defaultValue)
@@ -304,6 +308,10 @@ public class DevCycleClient {
         return getVariable(key: key, defaultValue: defaultValue)
     }
     public func variable(key: String, defaultValue: NSDictionary) -> DVCVariable<NSDictionary> {
+        return getVariable(key: key, defaultValue: defaultValue)
+    }
+    @available(*, deprecated, renamed: "variable()", message: "Use strictly typed versions of variable() methods")
+    public func variable<T>(key: String, defaultValue: T) -> DVCVariable<T> {
         return getVariable(key: key, defaultValue: defaultValue)
     }
 

--- a/DevCycleTests/Models/DevCycleClientTests.swift
+++ b/DevCycleTests/Models/DevCycleClientTests.swift
@@ -213,11 +213,12 @@ class DevCycleClientTest: XCTestCase {
     
     func testVariableDeprecatedMethod() {
         let client = try! self.builder.user(self.user).sdkKey("my_sdk_key").build(onInitialized: nil)
-        let variable = client.variable<Int>(key: "key", defaultValue: 1)
-        XCTAssertTrue(variable.value == 1)
+        let defaultVal: Int = 1
+        let variable = client.variable(key: "key", defaultValue: defaultVal)
+        XCTAssertTrue(variable.value == defaultVal)
         XCTAssertTrue(variable.isDefaulted)
-        let variableValue = client.variableValue<Int>(key: "key", defaultValue: 1)
-        XCTAssertTrue(variableValue == 1)
+        let variableValue = client.variableValue(key: "key", defaultValue: defaultVal)
+        XCTAssertTrue(variableValue == defaultVal)
         client.close(callback: nil)
     }
     

--- a/DevCycleTests/Models/DevCycleClientTests.swift
+++ b/DevCycleTests/Models/DevCycleClientTests.swift
@@ -211,6 +211,16 @@ class DevCycleClientTest: XCTestCase {
         client.close(callback: nil)
     }
     
+    func testVariableDeprecatedMethod() {
+        let client = try! self.builder.user(self.user).sdkKey("my_sdk_key").build(onInitialized: nil)
+        let variable = client.variable<Int>(key: "key", defaultValue: 1)
+        XCTAssertTrue(variable.value == 1)
+        XCTAssertTrue(variable.isDefaulted)
+        let variableValue = client.variableValue<Int>(key: "key", defaultValue: 1)
+        XCTAssertTrue(variableValue == 1)
+        client.close(callback: nil)
+    }
+    
     func testVariableReturnsDefaultForUnsupportedVariableKeys() {
         let client = try! self.builder.user(self.user).sdkKey("my_sdk_key").build(onInitialized: nil)
         let variable = client.variable(key: "UNSUPPORTED\\key%$", defaultValue: true)


### PR DESCRIPTION
This reverts a change that caused issues with the last release, where we removed the generic interfaces to `variable()` and `variableValue()`. These interfaces should have been left in the SDKs as deprecated methods to avoid breaking backward compatibility.