### PR TITLE
fix: batch event payloads into chunks of 100 to reduce errors on event processing

### DIFF
--- a/.github/workflows/ios.yaml
+++ b/.github/workflows/ios.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-13
+    runs-on: macos-13-large
     steps:
       - name: Checkout Project
         uses: actions/checkout@v4
@@ -21,4 +21,3 @@ jobs:
           use-xcframeworks: true
       - name: Fastlane iOS Tests
         run: fastlane ios tests
-

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-13
+    runs-on: macos-13-large
     steps:
       - name: Checkout Project
         uses: actions/checkout@v4

--- a/.github/workflows/tvos.yaml
+++ b/.github/workflows/tvos.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-13
+    runs-on: macos-13-large
     steps:
       - name: Checkout Project
         uses: actions/checkout@v4

--- a/.github/workflows/watchos.yaml
+++ b/.github/workflows/watchos.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-13
+    runs-on: macos-13-large
     steps:
       - name: Checkout Project
         uses: actions/checkout@v4

--- a/DevCycle/Networking/DevCycleService.swift
+++ b/DevCycle/Networking/DevCycleService.swift
@@ -94,7 +94,6 @@ class DevCycleService: DevCycleServiceProtocol {
     }
     
     func publishEvents(events: [DevCycleEvent], user: DevCycleUser, completion: @escaping PublishEventsCompletionHandler) {
-        print("in real publishEvents")
         var eventsRequest = createEventsRequest()
         let userEncoder = JSONEncoder()
         userEncoder.dateEncodingStrategy = .iso8601

--- a/DevCycle/Networking/DevCycleService.swift
+++ b/DevCycle/Networking/DevCycleService.swift
@@ -94,6 +94,7 @@ class DevCycleService: DevCycleServiceProtocol {
     }
     
     func publishEvents(events: [DevCycleEvent], user: DevCycleUser, completion: @escaping PublishEventsCompletionHandler) {
+        print("in real publishEvents")
         var eventsRequest = createEventsRequest()
         let userEncoder = JSONEncoder()
         userEncoder.dateEncodingStrategy = .iso8601
@@ -134,7 +135,7 @@ class DevCycleService: DevCycleServiceProtocol {
                 // Continue with next batch
                 startIndex = endIndex
                 endIndex = min(endIndex + self.maxBatchSize, totalEventsCount)
-                
+
                 if startIndex >= totalEventsCount {
                     return completion((data, response, nil))
                 }

--- a/DevCycleTests/Models/DevCycleClientTests.swift
+++ b/DevCycleTests/Models/DevCycleClientTests.swift
@@ -242,6 +242,7 @@ class DevCycleClientTest: XCTestCase {
 
     func testVariableMethodReturnsDefaultedVariableWhenKeyIsNotInConfig() {
         let client = try! self.builder.user(self.user).sdkKey("my_sdk_key").build(onInitialized: nil)
+        client.setup(service: self.service)
         client.config?.userConfig = self.userConfig
         client.initialize(callback: nil)
 
@@ -252,7 +253,6 @@ class DevCycleClientTest: XCTestCase {
         
         let variableValue = client.variableValue(key: "some_non_existent_variable", defaultValue: false)
         XCTAssertFalse(variableValue)
-        client.close(callback: nil)
     }
     
     func testVariableStringDefaultValue() {
@@ -318,12 +318,13 @@ class DevCycleClientTest: XCTestCase {
         let nsDicDefault: NSDictionary = ["key":"val"]
         let variable2 = client.variable(key: "some_non_existent_variable", defaultValue: nsDicDefault)
         XCTAssertEqual(variable2.defaultValue, nsDicDefault)
-        XCTAssertEqual(variable2.type, DVCVariableTypes.JSON)        
+        XCTAssertEqual(variable2.type, DVCVariableTypes.JSON)
     }
 
     func testVariableMethodReturnsCorrectVariableForKey() {
         let client = try! self.builder.user(self.user).sdkKey("my_sdk_key").build(onInitialized: nil)
         client.initialize(callback: nil)
+        client.setup(service: self.service)
         client.config?.userConfig = self.userConfig
 
         let boolVar = client.variable(key: "bool-var", defaultValue: false)
@@ -354,6 +355,7 @@ class DevCycleClientTest: XCTestCase {
     func testVariableMethodReturnSameInstanceOfVariable() {
         let client = try! self.builder.user(self.user).sdkKey("my_sdk_key").build(onInitialized: nil)
         client.initialize(callback: nil)
+        client.setup(service: self.service)
         client.config?.userConfig = self.userConfig
 
         let boolVar = client.variable(key: "bool-var", defaultValue: false)
@@ -374,6 +376,7 @@ class DevCycleClientTest: XCTestCase {
     func testVariableMethodReturnsDifferentVariableForANewDefaultValue() {
         let client = try! self.builder.user(self.user).sdkKey("my_sdk_key").build(onInitialized: nil)
         client.initialize(callback: nil)
+        client.setup(service: self.service)
         client.config?.userConfig = self.userConfig
 
         var stringVar = client.variable(key: "string-var", defaultValue: "default value")

--- a/DevCycleTests/Models/EventQueueTests.swift
+++ b/DevCycleTests/Models/EventQueueTests.swift
@@ -82,7 +82,6 @@ private class MockService: DevCycleServiceProtocol {
     func getConfig(user: DevCycleUser, enableEdgeDB: Bool, extraParams: RequestParams?, completion: @escaping ConfigCompletionHandler) {}
     
     func publishEvents(events: [DevCycleEvent], user: DevCycleUser, completion: @escaping PublishEventsCompletionHandler) {
-        
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
             completion((nil, nil, nil))
         }

--- a/DevCycleTests/Networking/DevCycleServiceTests.swift
+++ b/DevCycleTests/Networking/DevCycleServiceTests.swift
@@ -72,10 +72,49 @@ class DevCycleServiceTests: XCTestCase {
     }
     
     func testProcessConfigReturnsNilIfBrokenJson() throws {
-        let service = getService()
         let data = "{\"config\":\"key}".data(using: .utf8)
         let config = processConfig(data)
         XCTAssertNil(config)
+    }
+    
+    func testFlushingEvents() {
+        let service = MockDevCycleService()
+        let eventQueue = EventQueue()
+        let user = try! DevCycleUser.builder().userId("user1").build()
+        let expectation = XCTestExpectation(description: "Events are flushed in a single batch")
+        
+        // Generate 205 custom events and add them to the queue
+        for i in 0..<10 {
+            let event = try! DevCycleEvent.builder().type("event_\(i)").build()
+            eventQueue.queue(event)
+        }
+        eventQueue.flush(service: service, user: user, callback: nil)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+            XCTAssertEqual(eventQueue.events.count, 0)
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertEqual(service.makeRequestCallCount, 1, "makeRequest should have been called 1 time")
+    }
+    
+    func testFlushingEventsInBatches() {
+        let service = MockDevCycleService()
+        let eventQueue = EventQueue()
+        let user = try! DevCycleUser.builder().userId("user1").build()
+        let expectation = XCTestExpectation(description: "Events are serially queued and flushed in multiple batches")
+        
+        // Generate 205 custom events and add them to the queue
+        for i in 0..<205 {
+            let event = try! DevCycleEvent.builder().type("event_\(i)").build()
+            eventQueue.queue(event)
+        }
+        eventQueue.flush(service: service, user: user, callback: nil)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+            XCTAssertEqual(eventQueue.events.count, 0)
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 3.0)
+        XCTAssertEqual(service.makeRequestCallCount, 3, "makeRequest should have been called 3 times")
     }
 }
 
@@ -111,6 +150,104 @@ extension DevCycleServiceTests {
         }
     }
 
+    class MockDevCycleService: DevCycleServiceProtocol {
+        func getConfig(user: DevCycle.DevCycleUser, enableEdgeDB: Bool, extraParams: DevCycle.RequestParams?, completion: @escaping DevCycle.ConfigCompletionHandler) {
+            // Empty Stub
+        }
+        
+        func saveEntity(user: DevCycle.DevCycleUser, completion: @escaping DevCycle.SaveEntityCompletionHandler) {
+            // Empty Stub
+        }
+        
+        var publishEventsCalled = false
+        var makeRequestCallCount = 0
+        let testMaxBatchSize = 100
+        
+        func publishEvents(events: [DevCycleEvent], user: DevCycleUser, completion: @escaping PublishEventsCompletionHandler) {
+            print("in mocked DevCycleServiceTests publishEvents")
+            publishEventsCalled = true
+            
+            let url = URL(string: "http://test.com/v1/events")!
+            var eventsRequest = URLRequest(url: url)
+            let userEncoder = JSONEncoder()
+            userEncoder.dateEncodingStrategy = .iso8601
+            guard let userId = user.userId, let userData = try? userEncoder.encode(user) else {
+                return completion((nil, nil, ClientError.MissingUser))
+            }
+            
+            let eventPayload = self.generateEventPayload(events, userId, nil)
+            guard let userBody = try? JSONSerialization.jsonObject(with: userData, options: .fragmentsAllowed) else {
+                return completion((nil, nil, ClientError.InvalidUser))
+            }
+
+            let totalEventsCount = eventPayload.count
+            var startIndex = 0
+            var endIndex = min(self.testMaxBatchSize, totalEventsCount)
+            
+            while startIndex < totalEventsCount {
+                let batchEvents = Array(eventPayload[startIndex..<endIndex])
+                
+                let requestBody: [String: Any] = [
+                    "events": batchEvents,
+                    "user": userBody
+                ]
+
+                let jsonBody = try? JSONSerialization.data(withJSONObject: requestBody, options: .prettyPrinted)
+                eventsRequest.httpBody = jsonBody
+                
+                self.makeRequest(request: eventsRequest) { data, response, error in
+                    // Continue with next batch
+                    startIndex = endIndex
+                    endIndex = min(endIndex + self.testMaxBatchSize, totalEventsCount)
+                    
+                    if startIndex >= totalEventsCount {
+                        return completion((data, response, nil))
+                    }
+                }
+            }
+        }
+        
+        func makeRequest(request: URLRequest, completion: @escaping CompletionHandler) {
+            self.makeRequestCallCount += 1
+            
+            // Mock implementation for makeRequest
+            let mockData = "Successfully flushed 100 events".data(using: .utf8)
+            let mockResponse = HTTPURLResponse(url: URL(string: "https://example.com")!, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: nil)
+            completion((mockData, mockResponse, nil))
+        }
+        
+        private func generateEventPayload(_ events: [DevCycleEvent], _ userId: String, _ featureVariables: [String:String]?) -> [[String:Any]] {
+            var eventsJSON: [[String:Any]] = []
+            let formatter = ISO8601DateFormatter()
+            
+            for event in events {
+                if event.type == nil {
+                    continue
+                }
+                let eventDate: Date = event.clientDate ?? Date()
+                var eventToPost: [String: Any] = [
+                    "type": event.type!,
+                    "clientDate": formatter.string(from: eventDate),
+                    "user_id": userId,
+                    "featureVars": featureVariables ?? [:]
+                ]
+
+                if (event.target != nil) { eventToPost["target"] = event.target }
+                if (event.value != nil) { eventToPost["value"] = event.value }
+                if (event.metaData != nil) { eventToPost["metaData"] = event.metaData }
+                if (event.type != "variableDefaulted" && event.type != "variableEvaluated") {
+                    eventToPost["customType"] = event.type
+                    eventToPost["type"] = "customEvent"
+                }
+                
+                eventsJSON.append(eventToPost)
+            }
+
+            return eventsJSON
+        }
+    }
+
+
     func getService(_ options: DevCycleOptions? = nil) -> DevCycleService {
         let user = getTestUser()
         let config = DVCConfig(sdkKey: "my_sdk_key", user: user)
@@ -122,7 +259,6 @@ extension DevCycleServiceTests {
             .userId("my_user")
             .build()
     }
-    
 }
 
 

--- a/DevCycleTests/Networking/DevCycleServiceTests.swift
+++ b/DevCycleTests/Networking/DevCycleServiceTests.swift
@@ -89,7 +89,7 @@ class DevCycleServiceTests: XCTestCase {
             eventQueue.queue(event)
         }
         eventQueue.flush(service: service, user: user, callback: nil)
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
             XCTAssertEqual(eventQueue.events.count, 0)
             expectation.fulfill()
         }
@@ -109,7 +109,7 @@ class DevCycleServiceTests: XCTestCase {
             eventQueue.queue(event)
         }
         eventQueue.flush(service: service, user: user, callback: nil)
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
             XCTAssertEqual(eventQueue.events.count, 0)
             expectation.fulfill()
         }
@@ -164,7 +164,6 @@ extension DevCycleServiceTests {
         let testMaxBatchSize = 100
         
         func publishEvents(events: [DevCycleEvent], user: DevCycleUser, completion: @escaping PublishEventsCompletionHandler) {
-            print("in mocked DevCycleServiceTests publishEvents")
             publishEventsCalled = true
             
             let url = URL(string: "http://test.com/v1/events")!


### PR DESCRIPTION
- send events payload in batches of 100 events to reduce errors
- switches the GH Actions image to `macos-13-large` 