### PR TITLE
fix: fixed streaming connection not connecting when control center is dismissed

### DIFF
--- a/DevCycle/DevCycleClient.swift
+++ b/DevCycle/DevCycleClient.swift
@@ -96,6 +96,10 @@ public class DevCycleClient {
                                                    selector: #selector(appMovedToForeground),
                                                    name: UIApplication.willEnterForegroundNotification,
                                                    object: nil)
+            NotificationCenter.default.addObserver(self,
+                                                   selector: #selector(appMovedToForeground),
+                                                   name: UIApplication.didBecomeActiveNotification,
+                                                   object: nil)
         #elseif os(watchOS)
             NotificationCenter.default.addObserver(self,
                                                    selector: #selector(appMovedToBackground),


### PR DESCRIPTION
# Changes

- added observer for when app becomes active to cover case when control center is dismissed so that we can reconnect the streaming connection for SSE

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
