### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tvos.yaml
+++ b/.github/workflows/tvos.yaml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: macos-latest


### PR DESCRIPTION
Potential fix for [https://github.com/DevCycleHQ/ios-client-sdk/security/code-scanning/5](https://github.com/DevCycleHQ/ios-client-sdk/security/code-scanning/5)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function. Based on the actions used in the workflow:
- `actions/checkout` requires `contents: read` to clone the repository.
- `DevCycleHQ/carthage-bootstrap` uses a custom token (`secrets.AUTOMATION_USER_TOKEN`) for authentication, so it does not require additional permissions.
- The other steps (`setup-xcode` and `fastlane`) do not interact with GitHub APIs and do not require additional permissions.

Thus, the minimal permissions required are `contents: read`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
