### PR TITLE
chore: Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/watchos.yaml
+++ b/.github/workflows/watchos.yaml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: macos-latest


### PR DESCRIPTION
Potential fix for [https://github.com/DevCycleHQ/ios-client-sdk/security/code-scanning/4](https://github.com/DevCycleHQ/ios-client-sdk/security/code-scanning/4)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function correctly. Based on the actions used in the workflow, the following permissions are likely sufficient:
- `contents: read` for accessing the repository's contents.
- `packages: read` for accessing any required packages.
- `pull-requests: write` if the workflow interacts with pull requests (e.g., adding comments or labels).

If the workflow does not require any write permissions, we will limit it to `contents: read` only.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
