### PR TITLE
fix: create and push the tag to properly trigger the cococapods publish action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,7 @@ jobs:
         if: inputs.draft != true
         run: |
           git tag v${{ steps.prepare-release.outputs.next-release-tag }}
-          git push origin v${{ steps.prepare-release.outputs.next-release-tag }}
+          git push --tags
 
       # This will automatically trigger publishing to Carthage and Swift Package Manager
       - uses: DevCycleHQ/release-action/create-release@v2.3.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,12 @@ jobs:
           git push origin HEAD:main
         if: inputs.draft != true
 
+      - name: Create and push tag
+        if: inputs.draft != true
+        run: |
+          git tag v${{ steps.prepare-release.outputs.next-release-tag }}
+          git push origin v${{ steps.prepare-release.outputs.next-release-tag }}
+
       # This will automatically trigger publishing to Carthage and Swift Package Manager
       - uses: DevCycleHQ/release-action/create-release@v2.3.0
         id: create-release


### PR DESCRIPTION
This PR updates the release workflow to explicitly create and push a version tag (prefixed with `v`) before creating the GitHub release. This ensures that tag-based workflows (like CocoaPods publishing) are triggered reliably, since tags created via the GitHub API do not fire the `push` event.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
