### PR TITLE
fix: making DVCVariable init functions public to properly test OF Provider

### DIFF
--- a/DevCycle/DVCVariable.swift
+++ b/DevCycle/DVCVariable.swift
@@ -37,38 +37,38 @@ func DVCVariableTypeFrom(classString: String) throws -> DVCVariableTypes {
     }
 }
 
-
 public class DVCVariable<T> {
     public var key: String
     public var type: DVCVariableTypes?
     public var handler: VariableValueHandler<T>?
     public var evalReason: String?
     public var isDefaulted: Bool
-    
+
     public var value: T
     public var defaultValue: T
-    
-    init(key: String, value: T?, defaultValue: T, evalReason: String?) {
+
+    public init(key: String, value: T?, defaultValue: T, evalReason: String?) {
         self.key = key
         self.value = value ?? defaultValue
         self.defaultValue = defaultValue
         self.isDefaulted = value == nil
         self.evalReason = evalReason
-        
+
         let classString = String(describing: T.self)
         do {
             self.type = try DVCVariableTypeFrom(classString: classString)
         } catch {
-            Log.warn("Variable \(key) is of unsupported type: \(classString). Use variables of type: " +
-                     "String / Boolean / NSNumber / Int / NSDictionary")
+            Log.warn(
+                "Variable \(key) is of unsupported type: \(classString). Use variables of type: "
+                    + "String / Boolean / NSNumber / Int / NSDictionary")
             self.value = defaultValue
             self.isDefaulted = true
         }
-        
+
         addNotificationObserver()
     }
-    
-    init(from variable: Variable, defaultValue: T) {
+
+    public init(from variable: Variable, defaultValue: T) {
         var defaulted = false
         self.key = variable.key
         self.defaultValue = defaultValue
@@ -78,15 +78,16 @@ public class DVCVariable<T> {
         do {
             self.type = try DVCVariableTypeFrom(classString: classString)
         } catch {
-            Log.warn("Variable \(variable.key) defaultValue is of unsupported type: \(classString). " +
-                     "Use variables of type: String / Boolean / NSNumber / Double / NSDictionary / Dictionary")
+            Log.warn(
+                "Variable \(variable.key) defaultValue is of unsupported type: \(classString). "
+                    + "Use variables of type: String / Boolean / NSNumber / Double / NSDictionary / Dictionary"
+            )
             self.value = defaultValue
             self.isDefaulted = true
             addNotificationObserver()
             return
         }
-        
-        
+
         if let value = variable.value as? T {
             self.value = value
         } else {
@@ -94,54 +95,56 @@ public class DVCVariable<T> {
             self.value = defaultValue
             defaulted = true
         }
-        
+
         self.isDefaulted = defaulted
         addNotificationObserver()
     }
-    
+
     func update(from variable: Variable) {
         self.type = variable.type
         self.evalReason = variable.evalReason
-        
+
         if let value = variable.value as? T {
             let oldValue = self.value
             self.value = value
             self.isDefaulted = false
             if let handler = self.handler,
-               !isEqual(oldValue, variable.value) {
+                !isEqual(oldValue, variable.value)
+            {
                 handler(value)
             }
         } else {
             Log.warn("Variable \(variable.key) does not match type of default value \(T.self))")
         }
     }
-    
+
     @objc func propertyChange(notification: Notification) {
         guard let userConfig = notification.userInfo?["new-user-config"] as? UserConfig else {
             return
         }
         if let variableFromApi = userConfig.variables[key] {
             self.update(from: variableFromApi)
-        } else if (!isEqual(self.value, self.defaultValue)) {
+        } else if !isEqual(self.value, self.defaultValue) {
             self.resetToDefault()
             self.handler?(value)
-        } else if (!self.isDefaulted) {
+        } else if !self.isDefaulted {
             self.isDefaulted = true
         }
     }
-    
+
     private func resetToDefault() {
         self.value = self.defaultValue
         self.isDefaulted = true
     }
-    
+
     private func addNotificationObserver() {
-        NotificationCenter.default.addObserver(self, selector: #selector(propertyChange(notification:)), name: Notification.Name(NotificationNames.NewUserConfig), object: nil)
+        NotificationCenter.default.addObserver(
+            self, selector: #selector(propertyChange(notification:)),
+            name: Notification.Name(NotificationNames.NewUserConfig), object: nil)
     }
-    
+
     public func onUpdate(handler: @escaping VariableValueHandler<T>) -> DVCVariable {
         self.handler = handler
         return self
     }
 }
-


### PR DESCRIPTION
- Updating DVCVariable `init` functions to be public so I can use them in tests for the `DevCycleOpenFeatureProvider` in its repo.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
