### PR TITLE
feat: add async versions of all public DevCycleClient methods with callbacks

### DIFF
--- a/DevCycle/DevCycleClient.swift
+++ b/DevCycle/DevCycleClient.swift
@@ -245,9 +245,6 @@ public class DevCycleClient {
 
     private func cacheUser(user: DevCycleUser) {
         self.cacheService.save(user: user)
-        if user.isAnonymous == true, let userId = user.userId {
-            self.cacheService.setAnonUserId(anonUserId: userId)
-        }
     }
 
     private func setupSSEConnection() {

--- a/DevCycle/DevCycleClient.swift
+++ b/DevCycle/DevCycleClient.swift
@@ -442,6 +442,23 @@ public class DevCycleClient {
             })
     }
 
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
+    public func identifyUser(user: DevCycleUser) async throws -> [String: Variable]? {
+        return try await withCheckedThrowingContinuation { continuation in
+            do {
+                try self.identifyUser(user: user) { error, variables in
+                    if let error = error {
+                        continuation.resume(throwing: error)
+                    } else {
+                        continuation.resume(returning: variables)
+                    }
+                }
+            } catch {
+                continuation.resume(throwing: error)
+            }
+        }
+    }
+
     public func resetUser(callback: IdentifyCompletedHandler? = nil) throws {
         self.cache = cacheService.load()
         self.flushEvents()
@@ -475,6 +492,23 @@ public class DevCycleClient {
             })
     }
 
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
+    public func resetUser() async throws -> [String: Variable]? {
+        return try await withCheckedThrowingContinuation { continuation in
+            do {
+                try self.resetUser { error, variables in
+                    if let error = error {
+                        continuation.resume(throwing: error)
+                    } else {
+                        continuation.resume(returning: variables)
+                    }
+                }
+            } catch {
+                continuation.resume(throwing: error)
+            }
+        }
+    }
+
     public func allFeatures() -> [String: Feature] {
         return self.config?.userConfig?.features ?? [:]
     }
@@ -495,6 +529,20 @@ public class DevCycleClient {
 
     public func flushEvents(callback: FlushCompletedHandler?) {
         self.flushEvents(callback)
+    }
+
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
+    public func flushEvents() async throws {
+        try await withCheckedThrowingContinuation {
+            (continuation: CheckedContinuation<Void, Error>) in
+            self.flushEvents({ error in
+                if let error = error {
+                    continuation.resume(throwing: error)
+                } else {
+                    continuation.resume(returning: ())
+                }
+            })
+        }
     }
 
     internal func flushEvents(_ callback: FlushCompletedHandler? = nil) {
@@ -527,6 +575,15 @@ public class DevCycleClient {
             callback?()
         })
         self.sseConnection?.close()
+    }
+
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
+    public func close() async {
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            self.close {
+                continuation.resume(returning: ())
+            }
+        }
     }
 
     public class ClientBuilder {
@@ -581,6 +638,25 @@ public class DevCycleClient {
             }
             self.client = DevCycleClient()
             return result
+        }
+
+        @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
+        public func build() async throws -> DevCycleClient {
+            return try await withCheckedThrowingContinuation { continuation in
+                do {
+                    var builtClient: DevCycleClient?
+                    _ = try self.build(onInitialized: { error in
+                        if let error = error {
+                            continuation.resume(throwing: error)
+                        } else if let builtClient = builtClient {
+                            continuation.resume(returning: builtClient)
+                        }
+                    })
+                    builtClient = self.client
+                } catch {
+                    continuation.resume(throwing: error)
+                }
+            }
         }
     }
 

--- a/DevCycle/DevCycleClient.swift
+++ b/DevCycle/DevCycleClient.swift
@@ -644,15 +644,15 @@ public class DevCycleClient {
         public func build() async throws -> DevCycleClient {
             return try await withCheckedThrowingContinuation { continuation in
                 do {
-                    var builtClient: DevCycleClient?
-                    _ = try self.build(onInitialized: { error in
+                    var resultClient: DevCycleClient?
+                    let client = try self.build(onInitialized: { error in
                         if let error = error {
                             continuation.resume(throwing: error)
-                        } else if let builtClient = builtClient {
-                            continuation.resume(returning: builtClient)
+                        } else if let resultClient = resultClient {
+                            continuation.resume(returning: resultClient)
                         }
                     })
-                    builtClient = self.client
+                    resultClient = client
                 } catch {
                     continuation.resume(throwing: error)
                 }

--- a/DevCycleTests/Mocks/URLSessionMock.swift
+++ b/DevCycleTests/Mocks/URLSessionMock.swift
@@ -12,7 +12,7 @@ class URLSessionDataTaskMock: URLSessionDataTask {
     init(closure: @escaping () -> Void) {
         self.closure = closure
     }
-    
+
     override func resume() {
         closure()
     }
@@ -25,7 +25,7 @@ class URLSessionMock: URLSession {
     override func dataTask(
         with request: URLRequest,
         completionHandler: @escaping CompletionHandler
-        ) -> URLSessionDataTask {
+    ) -> URLSessionDataTask {
         let data = self.data
         let error = self.error
         return URLSessionDataTaskMock {

--- a/DevCycleTests/Models/DVCVariableTests.swift
+++ b/DevCycleTests/Models/DVCVariableTests.swift
@@ -6,28 +6,33 @@
 //
 
 import XCTest
+
 @testable import DevCycle
 
 class DVCVariableTests: XCTestCase {
     func testVariableCreatedFromParams() {
-        let variable = DVCVariable(key: "key", value: nil, defaultValue: "default_value", evalReason: nil)
+        let variable = DVCVariable(
+            key: "key", value: nil, defaultValue: "default_value", evalReason: nil)
         XCTAssertNotNil(variable)
     }
-    
+
     func testVariableUpdatesFromVariable() throws {
         let data = """
-        {
-            "_id": "variable_id",
-            "key": "my_key",
-            "type": "String",
-            "value": "my_value"
-        }
-        """.data(using: .utf8)!
-        let variableDict = try JSONSerialization.jsonObject(with: data, options: .fragmentsAllowed) as! [String: Any]
+            {
+                "_id": "variable_id",
+                "key": "my_key",
+                "type": "String",
+                "value": "my_value"
+            }
+            """.data(using: .utf8)!
+        let variableDict =
+            try JSONSerialization.jsonObject(with: data, options: .fragmentsAllowed)
+            as! [String: Any]
         let variableFromApi = try Variable(from: variableDict)
-        let variable = DVCVariable(key: "my_key", value: nil, defaultValue: "my_default", evalReason: nil)
+        let variable = DVCVariable(
+            key: "my_key", value: nil, defaultValue: "my_default", evalReason: nil)
         XCTAssertNotNil(variable)
-        
+
         variable.update(from: variableFromApi)
         XCTAssertNotNil(variable)
         XCTAssertEqual(variable.key, "my_key")
@@ -37,17 +42,19 @@ class DVCVariableTests: XCTestCase {
         XCTAssertFalse(variable.isDefaulted)
         XCTAssertNil(variable.evalReason)
     }
-    
+
     func testStringVariableCreatedFromVariable() throws {
         let data = """
-        {
-            "_id": "variable_id",
-            "key": "my_key",
-            "type": "String",
-            "value": "my_value"
-        }
-        """.data(using: .utf8)!
-        let variableDict = try JSONSerialization.jsonObject(with: data, options: .fragmentsAllowed) as! [String: Any]
+            {
+                "_id": "variable_id",
+                "key": "my_key",
+                "type": "String",
+                "value": "my_value"
+            }
+            """.data(using: .utf8)!
+        let variableDict =
+            try JSONSerialization.jsonObject(with: data, options: .fragmentsAllowed)
+            as! [String: Any]
         let variableFromApi = try Variable(from: variableDict)
         let variable = DVCVariable(from: variableFromApi, defaultValue: "my_default")
         XCTAssertNotNil(variable)
@@ -58,17 +65,19 @@ class DVCVariableTests: XCTestCase {
         XCTAssertFalse(variable.isDefaulted)
         XCTAssertNil(variable.evalReason)
     }
-    
+
     func testBoolVariableCreatedFromVariable() throws {
         let data = """
-        {
-            "_id": "variable_id",
-            "key": "my_key",
-            "type": "Boolean",
-            "value": true
-        }
-        """.data(using: .utf8)!
-        let variableDict = try JSONSerialization.jsonObject(with: data, options: .fragmentsAllowed) as! [String: Any]
+            {
+                "_id": "variable_id",
+                "key": "my_key",
+                "type": "Boolean",
+                "value": true
+            }
+            """.data(using: .utf8)!
+        let variableDict =
+            try JSONSerialization.jsonObject(with: data, options: .fragmentsAllowed)
+            as! [String: Any]
         let variableFromApi = try Variable(from: variableDict)
         let variable = DVCVariable(from: variableFromApi, defaultValue: false)
         XCTAssertNotNil(variable)
@@ -79,17 +88,19 @@ class DVCVariableTests: XCTestCase {
         XCTAssertFalse(variable.isDefaulted)
         XCTAssertNil(variable.evalReason)
     }
-    
+
     func testNumberVariableCreatedFromVariable() throws {
         let data = """
-        {
-            "_id": "variable_id",
-            "key": "my_key",
-            "type": "Number",
-            "value": 2.3
-        }
-        """.data(using: .utf8)!
-        let variableDict = try JSONSerialization.jsonObject(with: data, options: .fragmentsAllowed) as! [String: Any]
+            {
+                "_id": "variable_id",
+                "key": "my_key",
+                "type": "Number",
+                "value": 2.3
+            }
+            """.data(using: .utf8)!
+        let variableDict =
+            try JSONSerialization.jsonObject(with: data, options: .fragmentsAllowed)
+            as! [String: Any]
         let variableFromApi = try Variable(from: variableDict)
         let variable = DVCVariable(from: variableFromApi, defaultValue: 1.1)
         XCTAssertNotNil(variable)
@@ -100,17 +111,19 @@ class DVCVariableTests: XCTestCase {
         XCTAssertFalse(variable.isDefaulted)
         XCTAssertNil(variable.evalReason)
     }
-    
+
     func testNumberDoubleVariableCreatedFromVariable() throws {
         let data = """
-        {
-            "_id": "variable_id",
-            "key": "my_key",
-            "type": "Number",
-            "value": 2.3
-        }
-        """.data(using: .utf8)!
-        let variableDict = try JSONSerialization.jsonObject(with: data, options: .fragmentsAllowed) as! [String: Any]
+            {
+                "_id": "variable_id",
+                "key": "my_key",
+                "type": "Number",
+                "value": 2.3
+            }
+            """.data(using: .utf8)!
+        let variableDict =
+            try JSONSerialization.jsonObject(with: data, options: .fragmentsAllowed)
+            as! [String: Any]
         let variableFromApi = try Variable(from: variableDict)
         let defaultDouble: Double = 1.1
         let variable = DVCVariable(from: variableFromApi, defaultValue: defaultDouble)
@@ -121,14 +134,16 @@ class DVCVariableTests: XCTestCase {
 
     func testNumberNSNumberVariableCreatedFromVariable() throws {
         let data = """
-        {
-            "_id": "variable_id",
-            "key": "my_key",
-            "type": "Number",
-            "value": 2.3
-        }
-        """.data(using: .utf8)!
-        let variableDict = try JSONSerialization.jsonObject(with: data, options: .fragmentsAllowed) as! [String: Any]
+            {
+                "_id": "variable_id",
+                "key": "my_key",
+                "type": "Number",
+                "value": 2.3
+            }
+            """.data(using: .utf8)!
+        let variableDict =
+            try JSONSerialization.jsonObject(with: data, options: .fragmentsAllowed)
+            as! [String: Any]
         let variableFromApi = try Variable(from: variableDict)
         let defaultInt: NSNumber = 1
         let variable = DVCVariable(from: variableFromApi, defaultValue: defaultInt)
@@ -136,17 +151,19 @@ class DVCVariableTests: XCTestCase {
         XCTAssertEqual(variable.type, DVCVariableTypes.Number)
         XCTAssertEqual(variable.defaultValue, defaultInt)
     }
-    
+
     func testNumberFloatVariableDefaultsFromVariable() throws {
         let data = """
-        {
-            "_id": "variable_id",
-            "key": "my_key",
-            "type": "Number",
-            "value": 2.3
-        }
-        """.data(using: .utf8)!
-        let variableDict = try JSONSerialization.jsonObject(with: data, options: .fragmentsAllowed) as! [String: Any]
+            {
+                "_id": "variable_id",
+                "key": "my_key",
+                "type": "Number",
+                "value": 2.3
+            }
+            """.data(using: .utf8)!
+        let variableDict =
+            try JSONSerialization.jsonObject(with: data, options: .fragmentsAllowed)
+            as! [String: Any]
         let variableFromApi = try Variable(from: variableDict)
         let defaultFloat: Float = 1.1
         let variable = DVCVariable(from: variableFromApi, defaultValue: defaultFloat)
@@ -154,17 +171,19 @@ class DVCVariableTests: XCTestCase {
         XCTAssertEqual(variable.type, nil)
         XCTAssertTrue(variable.isDefaulted)
     }
-    
+
     func testNumberIntVariableDefaultsFromVariable() throws {
         let data = """
-        {
-            "_id": "variable_id",
-            "key": "my_key",
-            "type": "Number",
-            "value": 2.3
-        }
-        """.data(using: .utf8)!
-        let variableDict = try JSONSerialization.jsonObject(with: data, options: .fragmentsAllowed) as! [String: Any]
+            {
+                "_id": "variable_id",
+                "key": "my_key",
+                "type": "Number",
+                "value": 2.3
+            }
+            """.data(using: .utf8)!
+        let variableDict =
+            try JSONSerialization.jsonObject(with: data, options: .fragmentsAllowed)
+            as! [String: Any]
         let variableFromApi = try Variable(from: variableDict)
         let defaultInt: Int = 1
         let variable = DVCVariable(from: variableFromApi, defaultValue: defaultInt)
@@ -172,22 +191,24 @@ class DVCVariableTests: XCTestCase {
         XCTAssertEqual(variable.type, nil)
         XCTAssertTrue(variable.isDefaulted)
     }
-    
+
     func testJsonVariableCreatedFromVariable() throws {
         let data = """
-        {
-            "_id": "variable_id",
-            "key": "my_key",
-            "type": "JSON",
-            "value": {
-                "key1": "value1",
-                "key2": {
-                    "nestedKey1": "nestedKey2"
+            {
+                "_id": "variable_id",
+                "key": "my_key",
+                "type": "JSON",
+                "value": {
+                    "key1": "value1",
+                    "key2": {
+                        "nestedKey1": "nestedKey2"
+                    }
                 }
             }
-        }
-        """.data(using: .utf8)!
-        let variableDict = try JSONSerialization.jsonObject(with: data, options: .fragmentsAllowed) as! [String: Any]
+            """.data(using: .utf8)!
+        let variableDict =
+            try JSONSerialization.jsonObject(with: data, options: .fragmentsAllowed)
+            as! [String: Any]
         let variableFromApi = try Variable(from: variableDict)
         let defaultValue: [String: Any] = ["key1": "value2"]
         let variable = DVCVariable(from: variableFromApi, defaultValue: defaultValue)
@@ -199,45 +220,49 @@ class DVCVariableTests: XCTestCase {
         XCTAssertEqual(variable.defaultValue["key1"] as! String, "value2")
         XCTAssertFalse(variable.isDefaulted)
         XCTAssertNil(variable.evalReason)
-        
-        let nsDicDefault: NSDictionary = ["key1":"val"]
+
+        let nsDicDefault: NSDictionary = ["key1": "val"]
         let variable2 = DVCVariable(from: variableFromApi, defaultValue: nsDicDefault)
         XCTAssertEqual(variable2.value["key1"] as! String, "value1")
         XCTAssertEqual(variable2.type, DVCVariableTypes.JSON)
         XCTAssertEqual(variable2.defaultValue["key1"] as! String, "val")
     }
-    
+
     func testReturnsDefaultValueIfValueDoesntMatchDefaultValue() throws {
         let data = """
-        {
-            "_id": "variable_id",
-            "key": "my_key",
-            "type": "String",
-            "value": "my_value"
-        }
-        """.data(using: .utf8)!
-        let variableDict = try JSONSerialization.jsonObject(with: data, options: .fragmentsAllowed) as! [String: Any]
+            {
+                "_id": "variable_id",
+                "key": "my_key",
+                "type": "String",
+                "value": "my_value"
+            }
+            """.data(using: .utf8)!
+        let variableDict =
+            try JSONSerialization.jsonObject(with: data, options: .fragmentsAllowed)
+            as! [String: Any]
         let variableFromApi = try Variable(from: variableDict)
         let variable = DVCVariable(from: variableFromApi, defaultValue: 4)
         XCTAssertEqual(variable.value, 4)
         XCTAssertTrue(variable.isDefaulted)
     }
-    
+
     func testReturnsDefaultValueIfJSONObjectDoesntMatch() throws {
         let data = """
-        {
-            "_id": "variable_id",
-            "key": "my_key",
-            "type": "JSON",
-            "value": {
-                "key1": "value1",
-                "key2": {
-                    "nestedKey1": 610
+            {
+                "_id": "variable_id",
+                "key": "my_key",
+                "type": "JSON",
+                "value": {
+                    "key1": "value1",
+                    "key2": {
+                        "nestedKey1": 610
+                    }
                 }
             }
-        }
-        """.data(using: .utf8)!
-        let variableDict = try JSONSerialization.jsonObject(with: data, options: .fragmentsAllowed) as! [String: Any]
+            """.data(using: .utf8)!
+        let variableDict =
+            try JSONSerialization.jsonObject(with: data, options: .fragmentsAllowed)
+            as! [String: Any]
         let variableFromApi = try Variable(from: variableDict)
         let defaultValue = ["key1": "value2"]
         let variable = DVCVariable(from: variableFromApi, defaultValue: defaultValue)
@@ -245,35 +270,40 @@ class DVCVariableTests: XCTestCase {
         XCTAssertEqual(variable.value, defaultValue)
         XCTAssertTrue(variable.isDefaulted)
     }
-    
+
     func testDefaultValueIfValueFromUpdateDoesntMatchDefaultValue() throws {
         let data = """
-        {
-            "_id": "variable_id",
-            "key": "my_key",
-            "type": "String",
-            "value": "my_value"
-        }
-        """.data(using: .utf8)!
-        let variableDict = try JSONSerialization.jsonObject(with: data, options: .fragmentsAllowed) as! [String: Any]
+            {
+                "_id": "variable_id",
+                "key": "my_key",
+                "type": "String",
+                "value": "my_value"
+            }
+            """.data(using: .utf8)!
+        let variableDict =
+            try JSONSerialization.jsonObject(with: data, options: .fragmentsAllowed)
+            as! [String: Any]
         let variableFromApi = try Variable(from: variableDict)
         let variable = DVCVariable(key: "my_key", value: nil, defaultValue: 4, evalReason: nil)
         variable.update(from: variableFromApi)
         XCTAssertEqual(variable.value, 4)
     }
-    
+
     func testOnUpdateGetsCalledIfValueChanges() throws {
         let data = """
-        {
-            "_id": "variable_id",
-            "key": "my_key",
-            "type": "String",
-            "value": "my_value"
-        }
-        """.data(using: .utf8)!
-        let variableDict = try JSONSerialization.jsonObject(with: data, options: .fragmentsAllowed) as! [String: Any]
+            {
+                "_id": "variable_id",
+                "key": "my_key",
+                "type": "String",
+                "value": "my_value"
+            }
+            """.data(using: .utf8)!
+        let variableDict =
+            try JSONSerialization.jsonObject(with: data, options: .fragmentsAllowed)
+            as! [String: Any]
         let variableFromApi = try Variable(from: variableDict)
-        let variable = DVCVariable(key: "my_key", value: nil, defaultValue: "new_value", evalReason: nil)
+        let variable = DVCVariable(
+            key: "my_key", value: nil, defaultValue: "new_value", evalReason: nil)
         let exp = expectation(description: "On Update Called With New Value")
         variable.onUpdate { value in
             exp.fulfill()
@@ -284,16 +314,19 @@ class DVCVariableTests: XCTestCase {
 
     func testOnUpdateDoesntGetCalledIfValueTheSame() throws {
         let data = """
-        {
-            "_id": "variable_id",
-            "key": "my_key",
-            "type": "String",
-            "value": "my_value"
-        }
-        """.data(using: .utf8)!
-        let variableDict = try JSONSerialization.jsonObject(with: data, options: .fragmentsAllowed) as! [String: Any]
+            {
+                "_id": "variable_id",
+                "key": "my_key",
+                "type": "String",
+                "value": "my_value"
+            }
+            """.data(using: .utf8)!
+        let variableDict =
+            try JSONSerialization.jsonObject(with: data, options: .fragmentsAllowed)
+            as! [String: Any]
         let variableFromApi = try Variable(from: variableDict)
-        let variable = DVCVariable(key: "my_key", value: nil, defaultValue: "my_value", evalReason: nil)
+        let variable = DVCVariable(
+            key: "my_key", value: nil, defaultValue: "my_value", evalReason: nil)
         var onUpdateCalled = false
         let exp = expectation(description: "On Update Not Called")
         variable.onUpdate { value in

--- a/DevCycleTests/Models/DevCycleClientTests.swift
+++ b/DevCycleTests/Models/DevCycleClientTests.swift
@@ -534,7 +534,6 @@ class DevCycleClientTest: XCTestCase {
     }
 
     func testIdentifyUserClearsCachedAnonymousUserId() {
-        CacheService().clearAnonUserId()
         // Build Anon User, generates a new UUID
         let anonUser1 = try! DevCycleUser.builder().isAnonymous(true).build()
         XCTAssertNotNil(anonUser1)

--- a/DevCycleTests/Models/DevCycleClientTests.swift
+++ b/DevCycleTests/Models/DevCycleClientTests.swift
@@ -5,88 +5,96 @@
 //
 
 import XCTest
-#if os(iOS) || os(tvOS)
-import UIKit
-#elseif os(watchOS)
-import WatchKit
-#endif
 
 @testable import DevCycle
 
+#if os(iOS) || os(tvOS)
+    import UIKit
+#elseif os(watchOS)
+    import WatchKit
+#endif
 
 class DevCycleClientTest: XCTestCase {
     private var service: MockService!
     private var user: DevCycleUser!
     private var builder: DevCycleClient.ClientBuilder!
     private var userConfig: UserConfig!
-    
+
     override func setUp() {
         self.service = MockService()
         self.user = try! DevCycleUser.builder()
-                    .userId("my_user")
-                    .build()
+            .userId("my_user")
+            .build()
         self.builder = DevCycleClient.builder().service(service)
 
         let data = getConfigData(name: "test_config")
-        let dictionary = try! JSONSerialization.jsonObject(with: data, options: .fragmentsAllowed) as! [String:Any]
+        let dictionary =
+            try! JSONSerialization.jsonObject(with: data, options: .fragmentsAllowed)
+            as! [String: Any]
         self.userConfig = try! UserConfig(from: dictionary)
     }
-        
+
     func testBuilderReturnsNilIfNoSDKKey() {
         XCTAssertNil(try? self.builder.user(self.user).build(onInitialized: nil))
     }
-    
+
     func testBuilderReturnsNilIfNoUser() {
         XCTAssertNil(try? self.builder.sdkKey("my_sdk_key").build(onInitialized: nil))
     }
-    
+
     func testBuilderReturnsClient() {
-        let client = try! self.builder.user(self.user).sdkKey("my_sdk_key").build(onInitialized: nil)
+        let client = try! self.builder.user(self.user).sdkKey("my_sdk_key").build(
+            onInitialized: nil)
         XCTAssertNotNil(client)
         XCTAssertNotNil(client.user)
         XCTAssertNotNil(client.sdkKey)
         XCTAssertNil(client.options)
         client.close(callback: nil)
     }
-    
+
     func testBuilderReturnsClientUsingEnvironmentKey() {
-        let client = try! self.builder.user(self.user).environmentKey("my_sdk_key").build(onInitialized: nil)
+        let client = try! self.builder.user(self.user).environmentKey("my_sdk_key").build(
+            onInitialized: nil)
         XCTAssertNotNil(client)
         XCTAssertNotNil(client.user)
         XCTAssertNotNil(client.sdkKey)
         XCTAssertNil(client.options)
         client.close(callback: nil)
     }
-    
+
     func testDeprecatedDVCClientWorks() {
         let builder = DVCClient.builder().service(service)
-        let client = try! builder.user(self.user).environmentKey("my_sdk_key").build(onInitialized: nil)
+        let client = try! builder.user(self.user).environmentKey("my_sdk_key").build(
+            onInitialized: nil)
         XCTAssertNotNil(client)
         XCTAssertNotNil(client.user)
         XCTAssertNotNil(client.sdkKey)
         XCTAssertNil(client.options)
         client.close(callback: nil)
     }
-    
+
     func testSetupCallsGetConfig() {
         let client = DevCycleClient()
-        let service = MockService() // will assert if getConfig was called
+        let service = MockService()  // will assert if getConfig was called
         client.setSDKKey("")
         client.setUser(self.user)
         client.setup(service: service)
         client.close(callback: nil)
     }
-    
+
     func testBuilderReturnsClientWithOptions() {
-        let options = DevCycleOptions.builder().disableEventLogging(false).flushEventsIntervalMs(100).build()
-        let client = try! self.builder.user(self.user).sdkKey("my_sdk_key").options(options).build(onInitialized: nil)
+        let options = DevCycleOptions.builder().disableEventLogging(false).flushEventsIntervalMs(
+            100
+        ).build()
+        let client = try! self.builder.user(self.user).sdkKey("my_sdk_key").options(options).build(
+            onInitialized: nil)
         XCTAssertNotNil(client)
         XCTAssertNotNil(client.options)
         XCTAssertNotNil(client.user)
         XCTAssertNotNil(client.sdkKey)
         client.close(callback: nil)
     }
-    
+
     func testTrackWithValidDevCycleEventNoOptionals() {
         let expectation = XCTestExpectation(description: "EventQueue has one event")
         let client = DevCycleClient()
@@ -101,12 +109,13 @@ class DevCycleClientTest: XCTestCase {
 
         wait(for: [expectation], timeout: 1.0)
     }
-    
+
     func testTrackWithValidDevCycleEventWithAllParamsDefined() {
         let expectation = XCTestExpectation(description: "EventQueue has one fully defined event")
         let client = DevCycleClient()
-        let metaData: [String:Any] = ["test1": "key", "test2": 2, "test3": false]
-        let event: DevCycleEvent = try! DevCycleEvent.builder().type("test").target("test").clientDate(Date()).value(1).metaData(metaData).build()
+        let metaData: [String: Any] = ["test1": "key", "test2": 2, "test3": false]
+        let event: DevCycleEvent = try! DevCycleEvent.builder().type("test").target("test")
+            .clientDate(Date()).value(1).metaData(metaData).build()
 
         client.track(event)
 
@@ -117,52 +126,57 @@ class DevCycleClientTest: XCTestCase {
 
         wait(for: [expectation], timeout: 1.0)
     }
-    
+
     func testTrackWithValidDevCycleEventWithAllParamsDefinedAndDoubleValue() {
         let expectation = XCTestExpectation(description: "EventQueue has one fully defined event")
         let client = DevCycleClient()
-        let metaData: [String:Any] = ["test1": "key", "test2": 2, "test3": false]
-        let event: DevCycleEvent = try! DevCycleEvent.builder().type("test").target("test").clientDate(Date()).value(364.25).metaData(metaData).build()
-        
+        let metaData: [String: Any] = ["test1": "key", "test2": 2, "test3": false]
+        let event: DevCycleEvent = try! DevCycleEvent.builder().type("test").target("test")
+            .clientDate(Date()).value(364.25).metaData(metaData).build()
+
         client.track(event)
-        
+
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
             XCTAssertTrue(client.eventQueue.events.count == 1)
             expectation.fulfill()
         }
-        
+
         wait(for: [expectation], timeout: 1.0)
     }
-    
+
     func testFlushEventsWithOneEventInQueue() {
         let expectation = XCTestExpectation(description: "EventQueue publishes an event")
         let options = DevCycleOptions.builder().flushEventsIntervalMs(100).build()
-        let service = MockService() // will assert if publishEvents was called
+        let service = MockService()  // will assert if publishEvents was called
 
-        let client = try! self.builder.user(self.user).sdkKey("my_sdk_key").options(options).service(service).build(onInitialized: nil)
-        
-        let event: DevCycleEvent = try! DevCycleEvent.builder().type("test").clientDate(Date()).build()
-        
+        let client = try! self.builder.user(self.user).sdkKey("my_sdk_key").options(options)
+            .service(service).build(onInitialized: nil)
+
+        let event: DevCycleEvent = try! DevCycleEvent.builder().type("test").clientDate(Date())
+            .build()
+
         client.track(event)
         client.flushEvents()
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.01) {
             XCTAssertTrue(service.publishCallCount == 1)
             expectation.fulfill()
         }
-        
+
         wait(for: [expectation], timeout: 1.0)
         client.close(callback: nil)
     }
-    
+
     func testFlushEventsWithOneEventInQueueAndCallback() {
         let expectation = XCTestExpectation(description: "EventQueue publishes an event")
         let options = DevCycleOptions.builder().flushEventsIntervalMs(100).build()
-        let service = MockService() // will assert if publishEvents was called
+        let service = MockService()  // will assert if publishEvents was called
 
-        let client = try! self.builder.user(self.user).sdkKey("my_sdk_key").options(options).service(service).build(onInitialized: nil)
-        
-        let event: DevCycleEvent = try! DevCycleEvent.builder().type("test").clientDate(Date()).build()
-        
+        let client = try! self.builder.user(self.user).sdkKey("my_sdk_key").options(options)
+            .service(service).build(onInitialized: nil)
+
+        let event: DevCycleEvent = try! DevCycleEvent.builder().type("test").clientDate(Date())
+            .build()
+
         client.track(event)
         client.flushEvents(callback: { error in
             XCTAssertNil(error)
@@ -175,25 +189,27 @@ class DevCycleClientTest: XCTestCase {
             XCTAssertTrue(service.publishCallCount == 1)
             expectation.fulfill()
         }
-        
+
         wait(for: [expectation], timeout: 2.0)
     }
-    
+
     func testCloseFlushesRemainingEvents() {
         let expectation = XCTestExpectation(description: "Close flushes remaining events")
         let options = DevCycleOptions.builder().flushEventsIntervalMs(10000).build()
-        let client = try! self.builder.user(self.user).sdkKey("my_sdk_key").options(options).build(onInitialized: nil)
-        let service = MockService() // will assert if publishEvents was called
+        let client = try! self.builder.user(self.user).sdkKey("my_sdk_key").options(options).build(
+            onInitialized: nil)
+        let service = MockService()  // will assert if publishEvents was called
         client.setup(service: service)
-        let event: DevCycleEvent = try! DevCycleEvent.builder().type("test").clientDate(Date()).build()
-        
+        let event: DevCycleEvent = try! DevCycleEvent.builder().type("test").clientDate(Date())
+            .build()
+
         client.track(event)
         client.close(callback: {
             DispatchQueue.main.asyncAfter(deadline: .now() + 5) {
                 XCTAssertEqual(service.publishCallCount, 1)
 
                 XCTAssertEqual(service.eventPublishCount, 1)
-                
+
                 client.flushEvents(callback: { error in
                     // test that later tracked events are ignored
                     XCTAssertEqual(service.publishCallCount, 1)
@@ -206,13 +222,14 @@ class DevCycleClientTest: XCTestCase {
         client.track(event)
         // this variable evaluated event should be prevented as well
         client.variable(key: "test-key", defaultValue: false)
-        
+
         wait(for: [expectation], timeout: 6.0)
         client.close(callback: nil)
     }
-    
+
     func testVariableDeprecatedMethod() {
-        let client = try! self.builder.user(self.user).sdkKey("my_sdk_key").build(onInitialized: nil)
+        let client = try! self.builder.user(self.user).sdkKey("my_sdk_key").build(
+            onInitialized: nil)
         let defaultVal: Int = 1
         let variable = client.variable(key: "key", defaultValue: defaultVal)
         XCTAssertTrue(variable.value == defaultVal)
@@ -221,18 +238,20 @@ class DevCycleClientTest: XCTestCase {
         XCTAssertTrue(variableValue == defaultVal)
         client.close(callback: nil)
     }
-    
+
     func testVariableReturnsDefaultForUnsupportedVariableKeys() {
-        let client = try! self.builder.user(self.user).sdkKey("my_sdk_key").build(onInitialized: nil)
+        let client = try! self.builder.user(self.user).sdkKey("my_sdk_key").build(
+            onInitialized: nil)
         let variable = client.variable(key: "UNSUPPORTED\\key%$", defaultValue: true)
         XCTAssertTrue(variable.value)
         let variableValue = client.variableValue(key: "UNSUPPORTED\\key%$", defaultValue: true)
         XCTAssertTrue(variableValue)
         client.close(callback: nil)
     }
-    
+
     func testVariableFunctionWorksIfVariableKeyHasSupportedCharacters() {
-        let client = try! self.builder.user(self.user).sdkKey("my_sdk_key").build(onInitialized: nil)
+        let client = try! self.builder.user(self.user).sdkKey("my_sdk_key").build(
+            onInitialized: nil)
         let variable = client.variable(key: "supported-keys_here", defaultValue: true)
         XCTAssertTrue(variable.value)
         let variableValue = client.variableValue(key: "supported-keys_here", defaultValue: true)
@@ -241,7 +260,8 @@ class DevCycleClientTest: XCTestCase {
     }
 
     func testVariableMethodReturnsDefaultedVariableWhenKeyIsNotInConfig() {
-        let client = try! self.builder.user(self.user).sdkKey("my_sdk_key").build(onInitialized: nil)
+        let client = try! self.builder.user(self.user).sdkKey("my_sdk_key").build(
+            onInitialized: nil)
         client.setup(service: self.service)
         client.config?.userConfig = self.userConfig
         client.initialize(callback: nil)
@@ -250,79 +270,86 @@ class DevCycleClientTest: XCTestCase {
         XCTAssertFalse(variable.value)
         XCTAssertTrue(variable.isDefaulted)
         XCTAssertFalse(variable.defaultValue)
-        
-        let variableValue = client.variableValue(key: "some_non_existent_variable", defaultValue: false)
+
+        let variableValue = client.variableValue(
+            key: "some_non_existent_variable", defaultValue: false)
         XCTAssertFalse(variableValue)
     }
-    
+
     func testVariableStringDefaultValue() {
-        let client = try! self.builder.user(self.user).sdkKey("my_sdk_key").build(onInitialized: nil)
+        let client = try! self.builder.user(self.user).sdkKey("my_sdk_key").build(
+            onInitialized: nil)
         client.config?.userConfig = self.userConfig
         client.initialize(callback: nil)
-        
+
         let variable = client.variable(key: "some_non_existent_variable", defaultValue: "string")
         XCTAssertEqual(variable.value, "string")
         XCTAssert(variable.isDefaulted)
         XCTAssertEqual(variable.defaultValue, "string")
         XCTAssertEqual(variable.type, DVCVariableTypes.String)
-        
+
         let nsString: NSString = "nsString"
         let varNSString = client.variable(key: "some_non_existent_variable", defaultValue: nsString)
         XCTAssertEqual(varNSString.defaultValue, nsString)
         XCTAssertEqual(varNSString.type, DVCVariableTypes.String)
     }
-    
+
     func testVariableBooleanDefaultValue() {
-        let client = try! self.builder.user(self.user).sdkKey("my_sdk_key").build(onInitialized: nil)
+        let client = try! self.builder.user(self.user).sdkKey("my_sdk_key").build(
+            onInitialized: nil)
         client.config?.userConfig = self.userConfig
         client.initialize(callback: nil)
-        
+
         let variable = client.variable(key: "some_non_existent_variable", defaultValue: true)
         XCTAssertEqual(variable.value, true)
         XCTAssert(variable.isDefaulted)
         XCTAssertEqual(variable.defaultValue, true)
         XCTAssertEqual(variable.type, DVCVariableTypes.Boolean)
     }
-    
+
     func testVariableNumberDefaultValue() {
-        let client = try! self.builder.user(self.user).sdkKey("my_sdk_key").build(onInitialized: nil)
+        let client = try! self.builder.user(self.user).sdkKey("my_sdk_key").build(
+            onInitialized: nil)
         client.config?.userConfig = self.userConfig
         client.initialize(callback: nil)
-        
+
         let double: Double = 10.1
         let variable = client.variable(key: "some_non_existent_variable", defaultValue: double)
         XCTAssertEqual(variable.value, double)
         XCTAssert(variable.isDefaulted)
         XCTAssertEqual(variable.defaultValue, double)
         XCTAssertEqual(variable.type, DVCVariableTypes.Number)
-        
+
         let nsNum: NSNumber = 10.1
         let variableNum = client.variable(key: "some_non_existent_variable", defaultValue: nsNum)
         XCTAssertEqual(variableNum.defaultValue, nsNum)
         XCTAssertEqual(variableNum.type, DVCVariableTypes.Number)
     }
-    
+
     func testVariableJSONDefaultValue() {
-        let client = try! self.builder.user(self.user).sdkKey("my_sdk_key").build(onInitialized: nil)
+        let client = try! self.builder.user(self.user).sdkKey("my_sdk_key").build(
+            onInitialized: nil)
         client.config?.userConfig = self.userConfig
         client.initialize(callback: nil)
-        
-        let defaultVal: Dictionary<String, Any> = ["key":"val"]
+
+        let defaultVal: [String: Any] = ["key": "val"]
         let variable = client.variable(key: "some_non_existent_variable", defaultValue: defaultVal)
         XCTAssertEqual(variable.value.keys, defaultVal.keys)
         XCTAssertEqual(variable.value["key"] as! String, defaultVal["key"] as! String)
         XCTAssert(variable.isDefaulted)
         XCTAssertEqual(variable.defaultValue["key"] as! String, defaultVal["key"] as! String)
         XCTAssertEqual(variable.type, DVCVariableTypes.JSON)
-        
-        let nsDicDefault: NSDictionary = ["key":"val"]
-        let variable2 = client.variable(key: "some_non_existent_variable", defaultValue: nsDicDefault)
+
+        let nsDicDefault: NSDictionary = ["key": "val"]
+        let variable2 = client.variable(
+            key: "some_non_existent_variable", defaultValue: nsDicDefault)
         XCTAssertEqual(variable2.defaultValue, nsDicDefault)
         XCTAssertEqual(variable2.type, DVCVariableTypes.JSON)
     }
 
     func testVariableMethodReturnsCorrectVariableForKey() {
-        let client = try! self.builder.user(self.user).sdkKey("my_sdk_key").build(onInitialized: nil)
+        let client = try! self.builder.user(self.user).sdkKey("my_sdk_key").build(
+            onInitialized: nil)
         client.initialize(callback: nil)
         client.setup(service: self.service)
         client.config?.userConfig = self.userConfig
@@ -345,15 +372,18 @@ class DevCycleClientTest: XCTestCase {
         let defaultDict: NSDictionary = ["some_key": "some_value"]
         let jsonVar = client.variable(key: "json-var", defaultValue: defaultDict)
         XCTAssertEqual(jsonVar.value["key1"] as! String, "value1")
-        XCTAssertEqual((jsonVar.value["key2"] as! NSDictionary)["nestedKey1"] as! String, "nestedValue1")
+        XCTAssertEqual(
+            (jsonVar.value["key2"] as! NSDictionary)["nestedKey1"] as! String, "nestedValue1")
         let jsonValue = client.variableValue(key: "json-var", defaultValue: defaultDict)
         XCTAssertEqual(jsonValue["key1"] as! String, "value1")
-        XCTAssertEqual((jsonValue["key2"] as! NSDictionary)["nestedKey1"] as! String, "nestedValue1")
+        XCTAssertEqual(
+            (jsonValue["key2"] as! NSDictionary)["nestedKey1"] as! String, "nestedValue1")
         client.close(callback: nil)
     }
 
     func testVariableMethodReturnSameInstanceOfVariable() {
-        let client = try! self.builder.user(self.user).sdkKey("my_sdk_key").build(onInitialized: nil)
+        let client = try! self.builder.user(self.user).sdkKey("my_sdk_key").build(
+            onInitialized: nil)
         client.initialize(callback: nil)
         client.setup(service: self.service)
         client.config?.userConfig = self.userConfig
@@ -374,7 +404,8 @@ class DevCycleClientTest: XCTestCase {
     }
 
     func testVariableMethodReturnsDifferentVariableForANewDefaultValue() {
-        let client = try! self.builder.user(self.user).sdkKey("my_sdk_key").build(onInitialized: nil)
+        let client = try! self.builder.user(self.user).sdkKey("my_sdk_key").build(
+            onInitialized: nil)
         client.initialize(callback: nil)
         client.setup(service: self.service)
         client.config?.userConfig = self.userConfig
@@ -383,14 +414,16 @@ class DevCycleClientTest: XCTestCase {
         XCTAssert(client.variable(key: "string-var", defaultValue: "default value") === stringVar)
 
         stringVar = client.variable(key: "string-var", defaultValue: "new default value")
-        XCTAssert(client.variable(key: "string-var", defaultValue: "new default value") === stringVar)
+        XCTAssert(
+            client.variable(key: "string-var", defaultValue: "new default value") === stringVar)
         client.close(callback: nil)
     }
 
     func testRefetchConfigUsesTheCorrectUser() {
         let service = MockService()
         let user1 = try! DevCycleUser.builder().userId("user1").build()
-        let client = try! DevCycleClient.builder().user(user1).sdkKey("my_sdk_key").build(onInitialized: nil)
+        let client = try! DevCycleClient.builder().user(user1).sdkKey("my_sdk_key").build(
+            onInitialized: nil)
         client.setup(service: service)
         client.initialized = true
 
@@ -411,20 +444,24 @@ class DevCycleClientTest: XCTestCase {
         XCTAssertEqual(service.numberOfConfigCalls, 6)
         client.close(callback: nil)
     }
-    
+
     func testSseCloseGetsCalledWhenBackgrounded() {
-        let client = try! self.builder.user(self.user).sdkKey("my_sdk_key").build(onInitialized: nil)
+        let client = try! self.builder.user(self.user).sdkKey("my_sdk_key").build(
+            onInitialized: nil)
         client.initialized = true
 
         let mockSSEConnection = MockSSEConnection()
         client.sseConnection = mockSSEConnection
         client.inactivityDelayMS = 0
         #if os(iOS) || os(tvOS)
-            NotificationCenter.default.post(name: UIApplication.willResignActiveNotification, object: nil)
+            NotificationCenter.default.post(
+                name: UIApplication.willResignActiveNotification, object: nil)
         #elseif os(watchOS)
-            NotificationCenter.default.post(name: WKExtension.applicationWillResignActiveNotification, object: nil)
+            NotificationCenter.default.post(
+                name: WKExtension.applicationWillResignActiveNotification, object: nil)
         #elseif os(macOS)
-            NotificationCenter.default.post(name: NSApplication.willResignActiveNotification, object: nil)
+            NotificationCenter.default.post(
+                name: NSApplication.willResignActiveNotification, object: nil)
         #endif
 
         let expectation = XCTestExpectation(description: "close gets called when backgrounded")
@@ -438,7 +475,8 @@ class DevCycleClientTest: XCTestCase {
     }
 
     func testSseReopenGetsCalledWhenForegrounded() {
-        let client = try! self.builder.user(self.user).sdkKey("my_sdk_key").build(onInitialized: nil)
+        let client = try! self.builder.user(self.user).sdkKey("my_sdk_key").build(
+            onInitialized: nil)
 
         client.initialized = true
 
@@ -446,11 +484,14 @@ class DevCycleClientTest: XCTestCase {
         mockSSEConnection.connected = false
         client.sseConnection = mockSSEConnection
         #if os(iOS) || os(tvOS)
-            NotificationCenter.default.post(name: UIApplication.willEnterForegroundNotification, object: nil)
+            NotificationCenter.default.post(
+                name: UIApplication.willEnterForegroundNotification, object: nil)
         #elseif os(watchOS)
-            NotificationCenter.default.post(name: WKExtension.applicationWillEnterForegroundNotification, object: nil)
+            NotificationCenter.default.post(
+                name: WKExtension.applicationWillEnterForegroundNotification, object: nil)
         #elseif os(macOS)
-            NotificationCenter.default.post(name: NSApplication.willBecomeActiveNotification, object: nil)
+            NotificationCenter.default.post(
+                name: NSApplication.willBecomeActiveNotification, object: nil)
         #endif
 
         let expectation = XCTestExpectation(description: "reopen gets called when foregrounded")
@@ -462,9 +503,10 @@ class DevCycleClientTest: XCTestCase {
         wait(for: [expectation], timeout: 2.0)
         client.close(callback: nil)
     }
-    
+
     func testSseReopenDoesntGetCalledWhenForegroundedBeforeInactivityDelay() {
-        let client = try! self.builder.user(self.user).sdkKey("my_sdk_key").build(onInitialized: nil)
+        let client = try! self.builder.user(self.user).sdkKey("my_sdk_key").build(
+            onInitialized: nil)
         client.initialized = true
 
         let mockSSEConnection = MockSSEConnection()
@@ -472,11 +514,14 @@ class DevCycleClientTest: XCTestCase {
         client.sseConnection = mockSSEConnection
         client.inactivityDelayMS = 120000
         #if os(iOS) || os(tvOS)
-            NotificationCenter.default.post(name: UIApplication.willEnterForegroundNotification, object: nil)
+            NotificationCenter.default.post(
+                name: UIApplication.willEnterForegroundNotification, object: nil)
         #elseif os(watchOS)
-            NotificationCenter.default.post(name: WKExtension.applicationWillEnterForegroundNotification, object: nil)
+            NotificationCenter.default.post(
+                name: WKExtension.applicationWillEnterForegroundNotification, object: nil)
         #elseif os(macOS)
-            NotificationCenter.default.post(name: NSApplication.willBecomeActiveNotification, object: nil)
+            NotificationCenter.default.post(
+                name: NSApplication.willBecomeActiveNotification, object: nil)
         #endif
 
         let expectation = XCTestExpectation(description: "reopen doesn't called when foregrounded")
@@ -488,14 +533,15 @@ class DevCycleClientTest: XCTestCase {
         }
         wait(for: [expectation], timeout: 2.0)
     }
-    
+
     func testIdentifyUserClearsCachedAnonymousUserId() {
         // Build Anon User, generates a new UUID
         let anonUser1 = try! DevCycleUser.builder().isAnonymous(true).build()
         XCTAssertNotNil(anonUser1)
-        
+
         // Call Identify with a NOT anonymous User, this should erase the Cached UUID of anonUser1
-        let client = try! self.builder.user(self.user).sdkKey("my_sdk_key").build(onInitialized: { [weak self] error in
+        let client = try! self.builder.user(self.user).sdkKey("my_sdk_key").build(onInitialized: {
+            [weak self] error in
             // Since the cached Anonymous User Id is only cleared on successful identify call,
             // the anonUser3.userId should be the same as anonUser1.userId
             let anonUser3 = try! DevCycleUser.builder().isAnonymous(true).build()
@@ -504,71 +550,119 @@ class DevCycleClientTest: XCTestCase {
         })
         client.config?.userConfig = self.userConfig
         client.initialize(callback: nil)
-        
-        try! client.identifyUser(user: self.user, callback: { [weak self] error, variables in
-            // Wait for successful identifyUser callback, then build a new anonymous User, which SHOULD generate a new UUID
-            let anonUser2 = try! DevCycleUser.builder().isAnonymous(true).build()
-            XCTAssertNotNil(anonUser2)
-            XCTAssertNotEqual(anonUser2.userId, anonUser1.userId)
-        })
+
+        try! client.identifyUser(
+            user: self.user,
+            callback: { [weak self] error, variables in
+                // Wait for successful identifyUser callback, then build a new anonymous User, which SHOULD generate a new UUID
+                let anonUser2 = try! DevCycleUser.builder().isAnonymous(true).build()
+                XCTAssertNotNil(anonUser2)
+                XCTAssertNotEqual(anonUser2.userId, anonUser1.userId)
+            })
         client.close(callback: nil)
     }
-    
+
     func testResetUserGeneratesANewAnonymousUserId() {
         let anonUser1 = try! DevCycleUser.builder().isAnonymous(true).build()
         XCTAssertNotNil(anonUser1)
-        
-        let client = try! self.builder.user(anonUser1).sdkKey("my_sdk_key").build(onInitialized: nil)
+
+        let client = try! self.builder.user(anonUser1).sdkKey("my_sdk_key").build(
+            onInitialized: nil)
         client.initialize(callback: nil)
         client.config?.userConfig = self.userConfig
-        
+
         try! client.resetUser()
-        
+
         // client.lastIdentifiedUser is updated to be the anonymous user when `resetUser` is called
         XCTAssertNotEqual(anonUser1.userId, client.lastIdentifiedUser?.userId)
         client.close(callback: nil)
     }
-    
-        func testDisableCustomEventLogging() {
-            let expectation = XCTestExpectation(description: "test disableCustomEventLogging")
-            let options = DevCycleOptions.builder().disableCustomEventLogging(true).flushEventsIntervalMs(100).build()
-            let service = MockService() // will assert if publishEvents was called
 
-            let client = try! self.builder.user(self.user).sdkKey("my_sdk_key").options(options).service(service).build(onInitialized: nil)
+    func testDisableCustomEventLogging() {
+        let expectation = XCTestExpectation(description: "test disableCustomEventLogging")
+        let options = DevCycleOptions.builder().disableCustomEventLogging(true)
+            .flushEventsIntervalMs(100).build()
+        let service = MockService()  // will assert if publishEvents was called
 
-            let event: DevCycleEvent = try! DevCycleEvent.builder().type("test").clientDate(Date()).build()
+        let client = try! self.builder.user(self.user).sdkKey("my_sdk_key").options(options)
+            .service(service).build(onInitialized: nil)
 
-            client.track(event)
-            client.flushEvents()
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                XCTAssertTrue(service.publishCallCount == 0)
-                expectation.fulfill()
-            }
+        let event: DevCycleEvent = try! DevCycleEvent.builder().type("test").clientDate(Date())
+            .build()
 
-            wait(for: [expectation], timeout: 1)
-            client.close(callback: nil)
-        }
-    
-        func testDisableAutomaticEventLogging() {
-            let expectation = XCTestExpectation(description: "test disableAutomaticEventLogging")
-            let options = DevCycleOptions.builder().disableAutomaticEventLogging(true).flushEventsIntervalMs(10000).build()
-            let service = MockService() // will assert if publishEvents was called
-    
-            let client = try! self.builder.user(self.user).sdkKey("my_sdk_key").options(options).service(service).build(onInitialized: nil)
-    
-            let event: DevCycleEvent = try! DevCycleEvent.builder().type("test").clientDate(Date()).build()
-    
-            client.variable(key: "test-key", defaultValue: false)
-            client.flushEvents()
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                XCTAssertTrue(service.publishCallCount == 0)
-                expectation.fulfill()
-            }
-    
-            wait(for: [expectation], timeout: 1.0)
-            client.close(callback: nil)
+        client.track(event)
+        client.flushEvents()
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            XCTAssertTrue(service.publishCallCount == 0)
+            expectation.fulfill()
         }
 
+        wait(for: [expectation], timeout: 1)
+        client.close(callback: nil)
+    }
+
+    func testDisableAutomaticEventLogging() {
+        let expectation = XCTestExpectation(description: "test disableAutomaticEventLogging")
+        let options = DevCycleOptions.builder().disableAutomaticEventLogging(true)
+            .flushEventsIntervalMs(10000).build()
+        let service = MockService()  // will assert if publishEvents was called
+
+        let client = try! self.builder.user(self.user).sdkKey("my_sdk_key").options(options)
+            .service(service).build(onInitialized: nil)
+
+        let event: DevCycleEvent = try! DevCycleEvent.builder().type("test").clientDate(Date())
+            .build()
+
+        client.variable(key: "test-key", defaultValue: false)
+        client.flushEvents()
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            XCTAssertTrue(service.publishCallCount == 0)
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 1.0)
+        client.close(callback: nil)
+    }
+
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
+    func testAsyncIdentifyUser() async throws {
+        let client = try self.builder.user(self.user).sdkKey("my_sdk_key").service(service).build(
+            onInitialized: nil)
+        client.config?.userConfig = self.userConfig
+        client.initialize(callback: nil)
+        let variables = try await client.identifyUser(user: self.user)
+        XCTAssertNotNil(variables)
+        client.close(callback: nil)
+    }
+
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
+    func testAsyncResetUser() async throws {
+        let client = try self.builder.user(self.user).sdkKey("my_sdk_key").service(service).build(
+            onInitialized: nil)
+        client.config?.userConfig = self.userConfig
+        client.initialize(callback: nil)
+        let variables = try await client.resetUser()
+        XCTAssertNotNil(variables)
+        client.close(callback: nil)
+    }
+
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
+    func testAsyncFlushEvents() async throws {
+        let client = try self.builder.user(self.user).sdkKey("my_sdk_key").service(service).build(
+            onInitialized: nil)
+        let event: DevCycleEvent = try! DevCycleEvent.builder().type("test").clientDate(Date())
+            .build()
+        client.track(event)
+        try await client.flushEvents()
+        client.close(callback: nil)
+    }
+
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
+    func testAsyncClose() async throws {
+        let client = try self.builder.user(self.user).sdkKey("my_sdk_key").service(service).build(
+            onInitialized: nil)
+        await client.close()
+    }
 }
 
 extension DevCycleClientTest {
@@ -578,48 +672,56 @@ extension DevCycleClientTest {
         public var numberOfConfigCalls: Int = 0
         public var eventPublishCount: Int = 0
 
-        func getConfig(user: DevCycleUser, enableEdgeDB: Bool, extraParams: RequestParams?, completion: @escaping ConfigCompletionHandler) {
+        func getConfig(
+            user: DevCycleUser, enableEdgeDB: Bool, extraParams: RequestParams?,
+            completion: @escaping ConfigCompletionHandler
+        ) {
             self.userForGetConfig = user
             self.numberOfConfigCalls += 1
 
             XCTAssert(true)
         }
 
-        func publishEvents(events: [DevCycleEvent], user: DevCycleUser, completion: @escaping PublishEventsCompletionHandler) {
+        func publishEvents(
+            events: [DevCycleEvent], user: DevCycleUser,
+            completion: @escaping PublishEventsCompletionHandler
+        ) {
             self.publishCallCount += 1
             self.eventPublishCount += events.count
             XCTAssert(true)
-            Timer.scheduledTimer(withTimeInterval: 0.1, repeats: false, block: { timer in
-                completion((data: nil, urlResponse: nil, error: nil))
-            })
+            Timer.scheduledTimer(
+                withTimeInterval: 0.1, repeats: false,
+                block: { timer in
+                    completion((data: nil, urlResponse: nil, error: nil))
+                })
         }
-        
+
         func saveEntity(user: DevCycleUser, completion: @escaping SaveEntityCompletionHandler) {
             XCTAssert(true)
         }
-        
+
         func makeRequest(request: URLRequest, completion: @escaping DevCycle.CompletionHandler) {
             XCTAssert(true)
         }
     }
-    
+
     private class MockSSEConnection: SSEConnectionProtocol {
         var connected: Bool
         var reopenCalled: Bool
         var closeCalled: Bool
-        
+
         init() {
             self.connected = false
             self.reopenCalled = false
             self.closeCalled = false
         }
-        
+
         func openConnection() {}
-        
+
         func close() {
             self.closeCalled = true
         }
-        
+
         func reopen() {
             self.reopenCalled = true
         }

--- a/DevCycleTests/Models/DevCycleUserTest.swift
+++ b/DevCycleTests/Models/DevCycleUserTest.swift
@@ -5,6 +5,7 @@
 //
 
 import XCTest
+
 @testable import DevCycle
 
 class DevCycleUserTest: XCTestCase {
@@ -27,16 +28,16 @@ class DevCycleUserTest: XCTestCase {
             XCTAssertNotNil(user.platformVersion)
             XCTAssertNotNil(user.deviceModel)
         #endif
-        
+
         XCTAssertNotNil(user.createdDate)
         XCTAssertNotNil(user.lastSeenDate)
         XCTAssert(user.sdkType == "mobile")
         XCTAssertNotNil(user.sdkVersion)
     }
-    
+
     func testDeprecatedDVCUser() {
         let user = try! DVCUser.builder()
-                    .build()
+            .build()
         XCTAssertNotNil(user)
         XCTAssert(UUID(uuidString: user.userId!) != nil)
         XCTAssertTrue(user.isAnonymous!)
@@ -44,45 +45,45 @@ class DevCycleUserTest: XCTestCase {
 
     func testBuilderReturnsAnonUserIfNoUserIdOrIsAnonymous() {
         let user = try! DevCycleUser.builder()
-                    .build()
+            .build()
         XCTAssertNotNil(user)
         XCTAssert(UUID(uuidString: user.userId!) != nil)
         XCTAssertTrue(user.isAnonymous!)
     }
-    
+
     func testBuilderReturnsAnonUserIfNoUserIdAndIsAnonymousIsFalse() {
         let user = try! DevCycleUser.builder()
-                    .isAnonymous(false)
-                    .build()
+            .isAnonymous(false)
+            .build()
         XCTAssertNotNil(user)
         XCTAssert(UUID(uuidString: user.userId!) != nil)
         XCTAssertTrue(user.isAnonymous!)
     }
-    
+
     func testBuilderReturnsUserIfUserIdSet() {
         let user = try! DevCycleUser.builder().userId("my_user").build()
         XCTAssertNotNil(user)
         XCTAssert(user.userId == "my_user")
         XCTAssert(!user.isAnonymous!)
     }
-    
+
     func testBuilderReturnsUserIfIsAnonymousSet() {
         let user = try! DevCycleUser.builder().isAnonymous(true).build()
         XCTAssertNotNil(user)
         XCTAssert(user.isAnonymous!)
         XCTAssert(UUID(uuidString: user.userId!) != nil)
     }
-    
+
     func testBuilderReturnsNilIfUserIdIsEmptyString() {
         let user = try? DevCycleUser.builder().userId("").build()
         XCTAssertNil(user)
     }
-    
+
     func testBuilderReturnsNilIfUserIdOnlyContainsWhitespaces() {
         let user = try? DevCycleUser.builder().userId(" ").build()
         XCTAssertNil(user)
     }
-    
+
     func testToStringOnlyOutputsNonNilProperties() {
         var components = URLComponents(string: "test.com")
         components?.queryItems = getTestUser().toQueryItems()
@@ -92,14 +93,14 @@ class DevCycleUserTest: XCTestCase {
         XCTAssert(urlString!.contains("isAnonymous=false"))
         XCTAssertFalse(urlString!.contains("country"))
     }
-    
+
     func testToStringOuputsDatesAndMapCorrectly() {
         var components = URLComponents(string: "test.com")
         components?.queryItems = getTestUser().toQueryItems()
         let urlString = components?.url?.absoluteString
         let params = urlString!.split(separator: "?")[1].split(separator: "&")
         for param in params {
-            if (param.contains("createdDate")) {
+            if param.contains("createdDate") {
                 let date = param.split(separator: "=").last!
                 XCTAssertNoThrow(Int(date), "")
             }
@@ -107,21 +108,21 @@ class DevCycleUserTest: XCTestCase {
         XCTAssert(urlString!.contains("customData=%7B%22custom%22:%22key%22%7D"))
         XCTAssert(urlString!.contains("privateCustomData=%7B%22custom2%22:%22key2%22%7D"))
     }
-    
+
     func testAnonymousUserIdCaching() {
         let cacheService = CacheService()
         cacheService.setAnonUserId(anonUserId: "123")
-        
+
         let anonUser = try! DevCycleUser.builder().isAnonymous(true).build()
         XCTAssertNotNil(anonUser)
         XCTAssert(anonUser.isAnonymous!)
         XCTAssertEqual(anonUser.userId, "123")
-        
+
         let anonUser2 = try! DevCycleUser.builder().isAnonymous(true).build()
         XCTAssertNotNil(anonUser2)
         XCTAssert(anonUser2.isAnonymous!)
         XCTAssertEqual(anonUser2.userId, "123")
-        
+
         cacheService.clearAnonUserId()
     }
 }

--- a/DevCycleTests/Models/EventQueueTests.swift
+++ b/DevCycleTests/Models/EventQueueTests.swift
@@ -6,10 +6,11 @@
 //
 
 import XCTest
+
 @testable import DevCycle
 
 class EventQueueTests: XCTestCase {
-    
+
     func testDeprecatedDVCEvent() {
         let eventQueue = EventQueue()
         let expectation = XCTestExpectation(description: "Events are serially queued")
@@ -21,7 +22,7 @@ class EventQueueTests: XCTestCase {
         }
         wait(for: [expectation], timeout: 3.0)
     }
-    
+
     func testSerialOrderOfEvents() {
         let eventQueue = EventQueue()
         let expectation = XCTestExpectation(description: "Events are serially queued")
@@ -50,27 +51,29 @@ class EventQueueTests: XCTestCase {
         }
         wait(for: [expectation], timeout: 3.0)
     }
-    
+
     func testFlushRequeuesIfErrorRetryable() {
         let eventQueue = EventQueue()
         let expectation = XCTestExpectation(description: "Flush Requeues Retryable Event")
         let event = try! DevCycleEvent.builder().type("event1").build()
         let user = try! DevCycleUser.builder().userId("user1").build()
         eventQueue.queue(event)
-        eventQueue.flush(service: MockWithErrorCodeService(errorCode: 500), user: user, callback: nil)
+        eventQueue.flush(
+            service: MockWithErrorCodeService(errorCode: 500), user: user, callback: nil)
         let result = XCTWaiter.wait(for: [expectation], timeout: 2.0)
         if result == XCTWaiter.Result.timedOut {
             XCTAssertEqual(eventQueue.events.count, 1)
         }
     }
-    
+
     func testFlushDoesntRequeueIfErrorNotRetryable() {
         let eventQueue = EventQueue()
         let expectation = XCTestExpectation(description: "Subsequent flushes are cancelled")
         let event = try! DevCycleEvent.builder().type("event1").build()
         let user = try! DevCycleUser.builder().userId("user1").build()
         eventQueue.queue(event)
-        eventQueue.flush(service: MockWithErrorCodeService(errorCode: 403), user: user, callback: nil)
+        eventQueue.flush(
+            service: MockWithErrorCodeService(errorCode: 403), user: user, callback: nil)
         let result = XCTWaiter.wait(for: [expectation], timeout: 2.0)
         if result == XCTWaiter.Result.timedOut {
             XCTAssertEqual(eventQueue.events.count, 0)
@@ -79,16 +82,22 @@ class EventQueueTests: XCTestCase {
 }
 
 private class MockService: DevCycleServiceProtocol {
-    func getConfig(user: DevCycleUser, enableEdgeDB: Bool, extraParams: RequestParams?, completion: @escaping ConfigCompletionHandler) {}
-    
-    func publishEvents(events: [DevCycleEvent], user: DevCycleUser, completion: @escaping PublishEventsCompletionHandler) {
+    func getConfig(
+        user: DevCycleUser, enableEdgeDB: Bool, extraParams: RequestParams?,
+        completion: @escaping ConfigCompletionHandler
+    ) {}
+
+    func publishEvents(
+        events: [DevCycleEvent], user: DevCycleUser,
+        completion: @escaping PublishEventsCompletionHandler
+    ) {
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
             completion((nil, nil, nil))
         }
     }
-    
+
     func saveEntity(user: DevCycleUser, completion: @escaping SaveEntityCompletionHandler) {}
-    
+
     func makeRequest(request: URLRequest, completion: @escaping DevCycle.CompletionHandler) {}
 }
 
@@ -97,9 +106,15 @@ class MockWithErrorCodeService: DevCycleServiceProtocol {
     init(errorCode: Int) {
         self.errorCode = errorCode
     }
-    
-    func getConfig(user: DevCycleUser, enableEdgeDB: Bool, extraParams: RequestParams?, completion: @escaping ConfigCompletionHandler) {}
-    func publishEvents(events: [DevCycleEvent], user: DevCycleUser, completion: @escaping PublishEventsCompletionHandler) {
+
+    func getConfig(
+        user: DevCycleUser, enableEdgeDB: Bool, extraParams: RequestParams?,
+        completion: @escaping ConfigCompletionHandler
+    ) {}
+    func publishEvents(
+        events: [DevCycleEvent], user: DevCycleUser,
+        completion: @escaping PublishEventsCompletionHandler
+    ) {
         let error = NSError(domain: "api.devcycle.com", code: self.errorCode)
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
             completion((nil, nil, error))

--- a/DevCycleTests/Models/SSEMessage.swift
+++ b/DevCycleTests/Models/SSEMessage.swift
@@ -4,19 +4,20 @@
 //
 
 import XCTest
-@testable import DevCycle;
+
+@testable import DevCycle
 
 class SSEMessageTests: XCTestCase {
     func testShouldInitFromJson() throws {
         let jsonData = """
-        {
-            \"id\":\"test_id\",
-            \"timestamp\":123,
-            \"channel\":\"dvc_mobile_test\",
-            \"data\":\"{\\\"etag\\\":\\\"\\\\\\\"123abc\\\\\\\"\\\",\\\"lastModified\\\":123}\",
-            \"name\":\"change\"
-        }
-        """.data(using: .utf8)
+            {
+                \"id\":\"test_id\",
+                \"timestamp\":123,
+                \"channel\":\"dvc_mobile_test\",
+                \"data\":\"{\\\"etag\\\":\\\"\\\\\\\"123abc\\\\\\\"\\\",\\\"lastModified\\\":123}\",
+                \"name\":\"change\"
+            }
+            """.data(using: .utf8)
 
         let dictionary = try JSONSerialization.jsonObject(with: jsonData!) as! [String: Any]
         let sseMessage = try SSEMessage(from: dictionary)
@@ -27,32 +28,36 @@ class SSEMessageTests: XCTestCase {
 
     func testShouldThrowInitErrorWhenDataFieldIsMissing() throws {
         let jsonData = """
-        {
-            \"id\":\"test_id\",
-            \"timestamp\":123,
-            \"channel\":\"dvc_mobile_test\",
-            \"name\":\"change\"
-        }
-        """.data(using: .utf8)
+            {
+                \"id\":\"test_id\",
+                \"timestamp\":123,
+                \"channel\":\"dvc_mobile_test\",
+                \"name\":\"change\"
+            }
+            """.data(using: .utf8)
         let dictionary = try JSONSerialization.jsonObject(with: jsonData!) as! [String: Any]
         XCTAssertThrowsError(try SSEMessage(from: dictionary)) { error in
-            XCTAssertEqual(error as! SSEMessage.SSEMessageError, SSEMessage.SSEMessageError.initError("No data field in SSE JSON"))
+            XCTAssertEqual(
+                error as! SSEMessage.SSEMessageError,
+                SSEMessage.SSEMessageError.initError("No data field in SSE JSON"))
         }
     }
 
     func testShouldThrowErrorWhenDataFieldIsUnparsable() throws {
         let jsonData = """
-        {
-            \"id\":\"test_id\",
-            \"timestamp\":123,
-            \"channel\":\"dvc_mobile_test\",
-            \"data\":\"{\\\"etag\\\":123abc\\\\\\\",\\\"lastModified\\\":123}\",
-            \"name\":\"change\"
-        }
-        """.data(using: .utf8)
+            {
+                \"id\":\"test_id\",
+                \"timestamp\":123,
+                \"channel\":\"dvc_mobile_test\",
+                \"data\":\"{\\\"etag\\\":123abc\\\\\\\",\\\"lastModified\\\":123}\",
+                \"name\":\"change\"
+            }
+            """.data(using: .utf8)
         let dictionary = try JSONSerialization.jsonObject(with: jsonData!) as! [String: Any]
         XCTAssertThrowsError(try SSEMessage(from: dictionary)) { error in
-            XCTAssertEqual(error as! SSEMessage.SSEMessageError, SSEMessage.SSEMessageError.initError("Failed to parse data field in SSE message"))
+            XCTAssertEqual(
+                error as! SSEMessage.SSEMessageError,
+                SSEMessage.SSEMessageError.initError("Failed to parse data field in SSE message"))
         }
     }
 }

--- a/DevCycleTests/Models/ThreadingTests.swift
+++ b/DevCycleTests/Models/ThreadingTests.swift
@@ -6,6 +6,7 @@
 //
 
 import XCTest
+
 @testable import DevCycle
 
 final class ThreadingTests: XCTestCase {
@@ -13,22 +14,26 @@ final class ThreadingTests: XCTestCase {
     private var user: DevCycleUser!
     private var builder: DevCycleClient.ClientBuilder!
     private var userConfig: UserConfig!
-    
+
     override func setUpWithError() throws {
         self.service = MockService()
         self.user = try! DevCycleUser.builder()
-                    .userId("my_user")
-                    .build()
+            .userId("my_user")
+            .build()
         self.builder = DevCycleClient.builder().service(service)
 
         let data = getConfigData(name: "test_config")
-        let dictionary = try! JSONSerialization.jsonObject(with: data, options: .fragmentsAllowed) as! [String:Any]
+        let dictionary =
+            try! JSONSerialization.jsonObject(with: data, options: .fragmentsAllowed)
+            as! [String: Any]
         self.userConfig = try! UserConfig(from: dictionary)
     }
 
     func testVariableWorksInASyncBlockOnMainThread() throws {
-        let client = try! self.builder.user(self.user).sdkKey("my_sdk_key").build(onInitialized: nil)
-        let expectation = expectation(description: "Expect calling variable in a sync block on the main thread doesn't crash")
+        let client = try! self.builder.user(self.user).sdkKey("my_sdk_key").build(
+            onInitialized: nil)
+        let expectation = expectation(
+            description: "Expect calling variable in a sync block on the main thread doesn't crash")
         DispatchQueue.global(qos: .userInitiated).async {
             DispatchQueue.main.sync {
                 client.variable(key: "test-key", defaultValue: false)
@@ -41,11 +46,17 @@ final class ThreadingTests: XCTestCase {
 }
 
 private class MockService: DevCycleServiceProtocol {
-    func getConfig(user: DevCycleUser, enableEdgeDB: Bool, extraParams: RequestParams?, completion: @escaping ConfigCompletionHandler) {}
-    
-    func publishEvents(events: [DevCycleEvent], user: DevCycleUser, completion: @escaping PublishEventsCompletionHandler) {}
-    
+    func getConfig(
+        user: DevCycleUser, enableEdgeDB: Bool, extraParams: RequestParams?,
+        completion: @escaping ConfigCompletionHandler
+    ) {}
+
+    func publishEvents(
+        events: [DevCycleEvent], user: DevCycleUser,
+        completion: @escaping PublishEventsCompletionHandler
+    ) {}
+
     func saveEntity(user: DevCycleUser, completion: @escaping SaveEntityCompletionHandler) {}
-    
+
     func makeRequest(request: URLRequest, completion: @escaping DevCycle.CompletionHandler) {}
 }

--- a/DevCycleTests/Models/UserConfigTests.swift
+++ b/DevCycleTests/Models/UserConfigTests.swift
@@ -5,12 +5,15 @@
 //
 
 import XCTest
-@testable import DevCycle;
+
+@testable import DevCycle
 
 class UserConfigTests: XCTestCase {
     func testCreatesConfigFromData() throws {
         let data = getConfigData(name: "test_config")
-        let dictionary = try JSONSerialization.jsonObject(with: data, options: .fragmentsAllowed) as! [String:Any]
+        let dictionary =
+            try JSONSerialization.jsonObject(with: data, options: .fragmentsAllowed)
+            as! [String: Any]
         let config = try UserConfig(from: dictionary)
         XCTAssertNotNil(config)
         XCTAssertNotNil(config.project)
@@ -20,43 +23,47 @@ class UserConfigTests: XCTestCase {
         XCTAssertNotNil(config.features)
         XCTAssertNotNil(config.sse)
     }
-    
+
     func testDoesntCreateConfigFromDataIfProjectOrEnvironmentMissing() throws {
         let data = """
-        {
-            "project": {},
-            "environment": {},
-            "features": {},
-            "featureVariationMap": {},
-            "knownVariableKeys": [],
-            "variables": {}
-        }
+            {
+                "project": {},
+                "environment": {},
+                "features": {},
+                "featureVariationMap": {},
+                "knownVariableKeys": [],
+                "variables": {}
+            }
 
-        """.data(using: .utf8)!
-        let dictionary = try JSONSerialization.jsonObject(with: data, options: .fragmentsAllowed) as! [String:Any]
+            """.data(using: .utf8)!
+        let dictionary =
+            try JSONSerialization.jsonObject(with: data, options: .fragmentsAllowed)
+            as! [String: Any]
         let config = try? UserConfig(from: dictionary)
         XCTAssertNil(config)
     }
-    
+
     func testCreatesConfigFromDataIfNoFeaturesOrVariables() throws {
         let data = """
-        {
-            "project": {
-                "_id": "id1",
-                "key": "default"
-            },
-            "environment": {
-                "_id": "id2",
-                "key": "development"
-            },
-            "features": {},
-            "featureVariationMap": {},
-            "knownVariableKeys": [],
-            "variables": {}
-        }
+            {
+                "project": {
+                    "_id": "id1",
+                    "key": "default"
+                },
+                "environment": {
+                    "_id": "id2",
+                    "key": "development"
+                },
+                "features": {},
+                "featureVariationMap": {},
+                "knownVariableKeys": [],
+                "variables": {}
+            }
 
-        """.data(using: .utf8)!
-        let dictionary = try JSONSerialization.jsonObject(with: data, options: .fragmentsAllowed) as! [String:Any]
+            """.data(using: .utf8)!
+        let dictionary =
+            try JSONSerialization.jsonObject(with: data, options: .fragmentsAllowed)
+            as! [String: Any]
         let config = try UserConfig(from: dictionary)
         XCTAssertNotNil(config)
         XCTAssertNotNil(config.project)
@@ -65,40 +72,48 @@ class UserConfigTests: XCTestCase {
         XCTAssertNotNil(config.featureVariationMap)
         XCTAssertNotNil(config.features)
     }
-    
+
     func testConfigVariableBool() throws {
         let data = getConfigData(name: "test_config")
-        let dictionary = try JSONSerialization.jsonObject(with: data, options: .fragmentsAllowed) as! [String:Any]
+        let dictionary =
+            try JSONSerialization.jsonObject(with: data, options: .fragmentsAllowed)
+            as! [String: Any]
         let config = try UserConfig(from: dictionary)
         let variable = config.variables["bool-var"]
         XCTAssert(variable?.key == "bool-var")
         XCTAssertEqual(variable?.type, DVCVariableTypes.Boolean)
         XCTAssert((variable?.value as! Bool))
     }
-    
+
     func testConfigVariableString() throws {
         let data = getConfigData(name: "test_config")
-        let dictionary = try JSONSerialization.jsonObject(with: data, options: .fragmentsAllowed) as! [String:Any]
+        let dictionary =
+            try JSONSerialization.jsonObject(with: data, options: .fragmentsAllowed)
+            as! [String: Any]
         let config = try UserConfig(from: dictionary)
         let variable = config.variables["string-var"]
         XCTAssert(variable?.key == "string-var")
         XCTAssertEqual(variable?.type, DVCVariableTypes.String)
         XCTAssert((variable?.value as! String) == "string1")
     }
-    
+
     func testConfigVariableNumber() throws {
         let data = getConfigData(name: "test_config")
-        let dictionary = try JSONSerialization.jsonObject(with: data, options: .fragmentsAllowed) as! [String:Any]
+        let dictionary =
+            try JSONSerialization.jsonObject(with: data, options: .fragmentsAllowed)
+            as! [String: Any]
         let config = try UserConfig(from: dictionary)
         let variable = config.variables["num-var"]
         XCTAssert(variable?.key == "num-var")
         XCTAssertEqual(variable?.type, DVCVariableTypes.Number)
         XCTAssert((variable?.value as! Double) == 4)
     }
-    
+
     func testConfigVariableJson() throws {
         let data = getConfigData(name: "test_config")
-        let dictionary = try JSONSerialization.jsonObject(with: data, options: .fragmentsAllowed) as! [String:Any]
+        let dictionary =
+            try JSONSerialization.jsonObject(with: data, options: .fragmentsAllowed)
+            as! [String: Any]
         let config = try UserConfig(from: dictionary)
         let variable = config.variables["json-var"]
         let json = (variable?.value as! [String: Any])

--- a/DevCycleTests/Networking/DevCycleServiceTests.swift
+++ b/DevCycleTests/Networking/DevCycleServiceTests.swift
@@ -5,84 +5,89 @@
 //
 
 import XCTest
+
 @testable import DevCycle
 
 class DevCycleServiceTests: XCTestCase {
     func testCreateConfigURLRequest() throws {
-        let url = getService().createConfigRequest(user: getTestUser(), enableEdgeDB: false).url?.absoluteString
+        let url = getService().createConfigRequest(user: getTestUser(), enableEdgeDB: false).url?
+            .absoluteString
         XCTAssert(url!.contains("https://sdk-api.devcycle.com/v1/mobileSDKConfig"))
         XCTAssert(url!.contains("sdkKey=my_sdk_key"))
         XCTAssert(url!.contains("user_id=my_user"))
     }
-    
+
     func testProxyConfigURL() throws {
         let options = DevCycleOptions.builder().apiProxyURL("localhost:4000").build()
         let service = getService(options)
-        let url = service.createConfigRequest(user: getTestUser(), enableEdgeDB: false).url?.absoluteString
+        let url = service.createConfigRequest(user: getTestUser(), enableEdgeDB: false).url?
+            .absoluteString
         let eventsUrl = service.createEventsRequest().url?.absoluteString
-        
+
         XCTAssert(url!.contains("localhost:4000/v1/mobileSDKConfig"))
         XCTAssert(url!.contains("sdkKey=my_sdk_key"))
         XCTAssert(url!.contains("user_id=my_user"))
         XCTAssertFalse(eventsUrl!.contains("localhost:4000"))
     }
-    
+
     func testCreateConfigURLRequestWithEdgeDB() throws {
-        let url = getService().createConfigRequest(user: getTestUser(), enableEdgeDB: true).url?.absoluteString
+        let url = getService().createConfigRequest(user: getTestUser(), enableEdgeDB: true).url?
+            .absoluteString
         XCTAssert(url!.contains("https://sdk-api.devcycle.com/v1/mobileSDKConfig"))
         XCTAssert(url!.contains("sdkKey=my_sdk_key"))
         XCTAssert(url!.contains("user_id=my_user"))
         XCTAssert(url!.contains("enableEdgeDB=true"))
     }
-    
+
     func testCreateEventURLRequest() throws {
         let url = getService().createEventsRequest().url?.absoluteString
         XCTAssert(url!.contains("https://events.devcycle.com/v1/events"))
         XCTAssertFalse(url!.contains("user_id=my_user"))
     }
-    
+
     func testProxyEventUrl() throws {
         let options = DevCycleOptions.builder().eventsApiProxyURL("localhost:4000").build()
         let service = getService(options)
         let url = service.createEventsRequest().url?.absoluteString
-        let apiUrl = service.createConfigRequest(user: getTestUser(), enableEdgeDB: false).url?.absoluteString
-        
+        let apiUrl = service.createConfigRequest(user: getTestUser(), enableEdgeDB: false).url?
+            .absoluteString
+
         XCTAssert(url!.contains("localhost:4000/v1/events"))
         XCTAssertFalse(apiUrl!.contains("localhost:4000"))
         XCTAssertFalse(url!.contains("user_id=my_user"))
     }
-    
+
     func testCreateSaveEntityRequest() throws {
         let url = getService().createSaveEntityRequest().url?.absoluteString
         XCTAssert(url!.contains("https://sdk-api.devcycle.com/v1/edgedb"))
         XCTAssert(url!.contains("my_user"))
     }
-    
+
     func testProxyEntityUrl() throws {
         let options = DevCycleOptions.builder().apiProxyURL("localhost:4000").build()
         let url = getService(options).createSaveEntityRequest().url?.absoluteString
         XCTAssert(url!.contains("localhost:4000/v1/edgedb"))
         XCTAssert(url!.contains("my_user"))
     }
-    
+
     func testProcessConfigReturnsNilIfMissingProperties() throws {
         let data = "{\"config\":\"key\"}".data(using: .utf8)
         let config = processConfig(data)
         XCTAssertNil(config)
     }
-    
+
     func testProcessConfigReturnsNilIfBrokenJson() throws {
         let data = "{\"config\":\"key}".data(using: .utf8)
         let config = processConfig(data)
         XCTAssertNil(config)
     }
-    
+
     func testFlushingEvents() {
         let service = MockDevCycleService()
         let eventQueue = EventQueue()
         let user = try! DevCycleUser.builder().userId("user1").build()
         let expectation = XCTestExpectation(description: "10 Events are flushed in a single batch")
-        
+
         // Generate 205 custom events and add them to the queue
         for i in 0..<10 {
             let event = try! DevCycleEvent.builder().type("event_\(i)").build()
@@ -95,15 +100,16 @@ class DevCycleServiceTests: XCTestCase {
         }
         wait(for: [expectation], timeout: 1.0)
         XCTAssertTrue(service.publishEventsCalled)
-        XCTAssertEqual(service.makeRequestCallCount, 1, "makeRequest should have been called 1 time")
+        XCTAssertEqual(
+            service.makeRequestCallCount, 1, "makeRequest should have been called 1 time")
     }
-    
+
     func testFlushingLargeNumberOfEvents() {
         let service = MockDevCycleService()
         let eventQueue = EventQueue()
         let user = try! DevCycleUser.builder().userId("user1").build()
         let expectation = XCTestExpectation(description: "205 Events are flushed in a single batch")
-        
+
         // Generate 205 custom events and add them to the queue
         for i in 0..<205 {
             let event = try! DevCycleEvent.builder().type("event_\(i)").build()
@@ -116,7 +122,8 @@ class DevCycleServiceTests: XCTestCase {
         }
         wait(for: [expectation], timeout: 3.0)
         XCTAssertTrue(service.publishEventsCalled)
-        XCTAssertEqual(service.makeRequestCallCount, 1, "makeRequest should have been called 1 times")
+        XCTAssertEqual(
+            service.makeRequestCallCount, 1, "makeRequest should have been called 1 times")
     }
 }
 
@@ -129,7 +136,7 @@ extension DevCycleServiceTests {
             self.loadCalled = true
             return Cache(config: nil, user: nil)
         }
-        
+
         func save(user: DevCycleUser) {
             self.saveUserCalled = true
         }
@@ -142,31 +149,43 @@ extension DevCycleServiceTests {
         func clearAnonUserId() {
             // TODO: update implementation for tests
         }
-        
+
         func saveConfig(user: DevCycleUser, fetchDate: Int, configToSave: Data?) {
             self.saveConfigCalled = true
         }
-        
+
         func getConfig(user: DevCycleUser, ttlMs: Int) -> UserConfig? {
             return nil
+        }
+
+        func getOrCreateAnonUserId() -> String {
+            return "mock-anon-id"
         }
     }
 
     class MockDevCycleService: DevCycleServiceProtocol {
-        func getConfig(user: DevCycle.DevCycleUser, enableEdgeDB: Bool, extraParams: DevCycle.RequestParams?, completion: @escaping DevCycle.ConfigCompletionHandler) {
+        func getConfig(
+            user: DevCycle.DevCycleUser, enableEdgeDB: Bool, extraParams: DevCycle.RequestParams?,
+            completion: @escaping DevCycle.ConfigCompletionHandler
+        ) {
             // Empty Stub
         }
-        
-        func saveEntity(user: DevCycle.DevCycleUser, completion: @escaping DevCycle.SaveEntityCompletionHandler) {
+
+        func saveEntity(
+            user: DevCycle.DevCycleUser, completion: @escaping DevCycle.SaveEntityCompletionHandler
+        ) {
             // Empty Stub
         }
-        
+
         var publishEventsCalled = false
         var makeRequestCallCount = 0
         let testMaxBatchSize = 100
         var sdkKey = "my_sdk_key"
-        
-        func publishEvents(events: [DevCycleEvent], user: DevCycleUser, completion: @escaping PublishEventsCompletionHandler) {
+
+        func publishEvents(
+            events: [DevCycleEvent], user: DevCycleUser,
+            completion: @escaping PublishEventsCompletionHandler
+        ) {
             publishEventsCalled = true
 
             let userEncoder = JSONEncoder()
@@ -174,28 +193,35 @@ extension DevCycleServiceTests {
             guard let userId = user.userId, let userData = try? userEncoder.encode(user) else {
                 return completion((nil, nil, ClientError.MissingUser))
             }
-            
+
             let eventPayload = self.generateEventPayload(events, userId, nil)
-            guard let userBody = try? JSONSerialization.jsonObject(with: userData, options: .fragmentsAllowed) else {
+            guard
+                let userBody = try? JSONSerialization.jsonObject(
+                    with: userData, options: .fragmentsAllowed)
+            else {
                 return completion((nil, nil, ClientError.InvalidUser))
             }
 
             self.batchEventsPayload(events: eventPayload, user: userBody, completion: completion)
         }
-        
+
         func makeRequest(request: URLRequest, completion: @escaping CompletionHandler) {
             self.makeRequestCallCount += 1
-            
+
             // Mock implementation for makeRequest
             let mockData = "Successfully flushed \(self.testMaxBatchSize) events".data(using: .utf8)
-            let mockResponse = HTTPURLResponse(url: URL(string: "https://example.com")!, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: nil)
+            let mockResponse = HTTPURLResponse(
+                url: URL(string: "https://example.com")!, statusCode: 200, httpVersion: "HTTP/1.1",
+                headerFields: nil)
             completion((mockData, mockResponse, nil))
         }
-        
-        private func generateEventPayload(_ events: [DevCycleEvent], _ userId: String, _ featureVariables: [String:String]?) -> [[String:Any]] {
-            var eventsJSON: [[String:Any]] = []
+
+        private func generateEventPayload(
+            _ events: [DevCycleEvent], _ userId: String, _ featureVariables: [String: String]?
+        ) -> [[String: Any]] {
+            var eventsJSON: [[String: Any]] = []
             let formatter = ISO8601DateFormatter()
-            
+
             for event in events {
                 if event.type == nil {
                     continue
@@ -205,24 +231,26 @@ extension DevCycleServiceTests {
                     "type": event.type!,
                     "clientDate": formatter.string(from: eventDate),
                     "user_id": userId,
-                    "featureVars": featureVariables ?? [:]
+                    "featureVars": featureVariables ?? [:],
                 ]
 
-                if (event.target != nil) { eventToPost["target"] = event.target }
-                if (event.value != nil) { eventToPost["value"] = event.value }
-                if (event.metaData != nil) { eventToPost["metaData"] = event.metaData }
-                if (event.type != "variableDefaulted" && event.type != "variableEvaluated") {
+                if event.target != nil { eventToPost["target"] = event.target }
+                if event.value != nil { eventToPost["value"] = event.value }
+                if event.metaData != nil { eventToPost["metaData"] = event.metaData }
+                if event.type != "variableDefaulted" && event.type != "variableEvaluated" {
                     eventToPost["customType"] = event.type
                     eventToPost["type"] = "customEvent"
                 }
-                
+
                 eventsJSON.append(eventToPost)
             }
 
             return eventsJSON
         }
 
-        private func batchEventsPayload(events: [[String:Any]], user: Any, completion: @escaping PublishEventsCompletionHandler) {
+        private func batchEventsPayload(
+            events: [[String: Any]], user: Any, completion: @escaping PublishEventsCompletionHandler
+        ) {
             let url = URL(string: "http://test.com/v1/events")!
             var eventsRequest = URLRequest(url: url)
             eventsRequest.httpMethod = "POST"
@@ -232,10 +260,11 @@ extension DevCycleServiceTests {
 
             let requestBody: [String: Any] = [
                 "events": events,
-                "user": user
+                "user": user,
             ]
 
-            let jsonBody = try? JSONSerialization.data(withJSONObject: requestBody, options: .prettyPrinted)
+            let jsonBody = try? JSONSerialization.data(
+                withJSONObject: requestBody, options: .prettyPrinted)
             Log.debug("Post Events Payload: \(String(data: jsonBody!, encoding: .utf8) ?? "")")
             eventsRequest.httpBody = jsonBody
 
@@ -249,18 +278,15 @@ extension DevCycleServiceTests {
         }
     }
 
-
     func getService(_ options: DevCycleOptions? = nil) -> DevCycleService {
         let user = getTestUser()
         let config = DVCConfig(sdkKey: "my_sdk_key", user: user)
         return DevCycleService(config: config, cacheService: MockCacheService(), options: options)
     }
-    
+
     func getTestUser() -> DevCycleUser {
         return try! DevCycleUser.builder()
             .userId("my_user")
             .build()
     }
 }
-
-

--- a/Examples/DevCycle-MacOS-Example-App/DevCycle-macOS-Example-App.xcodeproj/project.pbxproj
+++ b/Examples/DevCycle-MacOS-Example-App/DevCycle-macOS-Example-App.xcodeproj/project.pbxproj
@@ -359,7 +359,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.13;
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.devcycle.DevCycle-MacOS-Example-App";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -386,7 +386,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.13;
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.devcycle.DevCycle-MacOS-Example-App";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/Examples/DevCycle-MacOS-Example-App/DevCycle-macOS-Example-App/AppDelegate.swift
+++ b/Examples/DevCycle-MacOS-Example-App/DevCycle-macOS-Example-App/AppDelegate.swift
@@ -8,20 +8,27 @@ import DevCycle
 
 @main
 class AppDelegate: NSObject, NSApplicationDelegate {
-    
-    func applicationDidFinishLaunching(_ aNotification: Notification) {
-        // TODO: Set SDK Key in DevCycleManager.swift
-        
-        // Insert code here to initialize your application
-        // create anonymous user
-        let user = try? DevCycleUser.builder()
-                               .isAnonymous(true)
-                               .build()
-        
-        // initialize DevCycle
-        if let user = user {
+
+    override init() {
+        super.init()
+        do {
+            // TODO: Set SDK Key in DevCycleManager.swift
+
+            // Insert code here to initialize your application
+            // create anonymous user
+            let user = try DevCycleUser.builder()
+                .isAnonymous(true)
+                .build()
+            
+            // Initialize DevCycle
             DevCycleManager.shared.initialize(user: user)
+        } catch {
+            fatalError("Failed to build DevCycleUser: \(error)")
         }
+    }
+
+    func applicationDidFinishLaunching(_ aNotification: Notification) {
+        // No DevCycle initialization needed here
     }
 
     func applicationWillTerminate(_ aNotification: Notification) {
@@ -31,5 +38,5 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationSupportsSecureRestorableState(_ app: NSApplication) -> Bool {
         return true
     }
-    
+
 }

--- a/Examples/DevCycle-MacOS-Example-App/DevCycle-macOS-Example-App/DevCycleManager.swift
+++ b/Examples/DevCycle-MacOS-Example-App/DevCycle-macOS-Example-App/DevCycleManager.swift
@@ -3,31 +3,39 @@
 //  DevCycle-MacOS-Example-App
 //
 
-import Foundation
 import DevCycle
+import Foundation
 
 struct DevCycleKeys {
     static var DEVELOPMENT = "<DEVCYCLE_MOBILE_SDK_KEY>"
 }
 
 class DevCycleManager {
-    
-    var client: DevCycleClient?
+    private var client: DevCycleClient?
+    private var initializationTask: Task<DevCycleClient?, Never>?
     static let shared = DevCycleManager()
-    
+
     func initialize(user: DevCycleUser) {
-        let options = DevCycleOptions.builder()
-                                .logLevel(.debug)
-                                .build()
-        
-        guard let client = try? DevCycleClient.builder()
+        print("DVC Manager Initialize")
+        guard initializationTask == nil else { return }
+        initializationTask = Task {
+            let options = DevCycleOptions.builder()
+                .build()
+            let client = try? await DevCycleClient.builder()
                 .sdkKey(DevCycleKeys.DEVELOPMENT)
                 .user(user)
                 .options(options)
-                .build(onInitialized: nil)
-        else {
-            return
+                .build()
+            print("DVC Manager ")
+            self.client = client
+            return client
         }
-        self.client = client
+    }
+
+    var clientAsync: DevCycleClient? {
+        get async {
+            print("Get clientAsync")
+            return await initializationTask?.value
+        }
     }
 }

--- a/Examples/DevCycle-MacOS-Example-App/DevCycle-macOS-Example-App/ViewController.swift
+++ b/Examples/DevCycle-MacOS-Example-App/DevCycle-macOS-Example-App/ViewController.swift
@@ -10,35 +10,31 @@ class ViewController: NSViewController {
 
     @IBOutlet weak var titleHeader: NSTextField!
     @IBOutlet weak var loginButton: NSButton!
-    
+
     var loggedIn: Bool = false
-    var client: DevCycleClient?
     var titleHeaderVar: DVCVariable<String>?
     var loginCtaVar: DVCVariable<String>?
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
-        
-        // Wait for NSApplication.didFinishLaunching as default View Controller calls viewDidLoad() before applicationDidFinishLaunching on macOS
-        NotificationCenter.default.addObserver(self,
-                                               selector: #selector(didFinishLaunching),
-                                               name: NSApplication.didFinishLaunchingNotification,
-                                               object: nil)
-    }
-    
-    @objc func didFinishLaunching() {
-        // Do any additional setup after loading the view.
-        self.client = DevCycleManager.shared.client
-        self.loginCtaVar = client?.variable(key: "login-cta-copy", defaultValue: "Log").onUpdate(handler: { value in
-            self.setLoginButtonTitle(self.loggedIn)
-        })
-        self.titleHeaderVar = client?.variable(key: "title-header-copy", defaultValue: "DevCycle iOS Example App").onUpdate(handler: { value in
+
+        Task {
+            guard let client = await DevCycleManager.shared.clientAsync else { return }
+
+            self.loginCtaVar = client.variable(key: "login-cta-copy", defaultValue: "Log")
+                .onUpdate(handler: { value in
+                    self.setLoginButtonTitle(self.loggedIn)
+                })
+            self.titleHeaderVar = client.variable(
+                key: "title-header-copy", defaultValue: "DevCycle iOS Example App"
+            ).onUpdate(handler: { value in
+                self.setTitleHeader()
+            })
             self.setTitleHeader()
-        })
-        self.setTitleHeader()
-        self.setLoginButtonTitle(false)
+            self.setLoginButtonTitle(false)
+        }
     }
-    
+
     func setTitleHeader() {
         guard let titleHeaderVar = self.titleHeaderVar else {
             return
@@ -51,74 +47,79 @@ class ViewController: NSViewController {
             return
         }
         self.loggedIn = bool
-        self.loginButton.title = "\(loginCta.value) \(self.loggedIn ? "out" : "in")"
+        let loggedIn = bool
+
+        DispatchQueue.main.async {
+            self.loginButton.title = "\(loginCta.value) \(loggedIn ? "out" : "in")"
+            self.loginButton.displayIfNeeded()
+        }
     }
 
     @IBAction func loginButtonPressed(_ sender: Any) {
         print("Login Button")
-        
-        guard let client = self.client else { return }
-        if (self.loggedIn) {
-            try? client.resetUser { [weak self] error, variables in
-                guard let self = self else { return }
-                self.setLoginButtonTitle(false)
-                print("Reset User!")
-                print("Variables: \(String(describing: variables))")
-            }
-        } else {
-            let user = try? DevCycleUser.builder()
-                              .userId("my-user1")
-                              .email("my-email@email.com")
-                              .country("CA")
-                              .name("Ash Ketchum")
-                              .language("EN")
-                              .customData([
-                                "customkey": "customValue"
-                              ])
-                              .privateCustomData([
-                                "customkey2": "customValue2"
-                              ])
-                              .build()
-            try? client.identifyUser(user: user!) { [weak self] error, variables in
-                guard let self = self else { return }
-                self.setLoginButtonTitle(true)
-                print("Logged in as User: \(String(describing: user?.userId))!")
-                print("Variables: \(String(describing: variables))")
-                
-                let variable = client.variable(key: "num_key", defaultValue: 0)
-                let variable2 = client.variable(key: "num_key_defaulted", defaultValue: 0)
-                if (variable.value == 1) {
-                    print("Num_key is 1!")
-                } else {
-                    print("Num_key is 0!")
+        let isCurrentlyLoggedIn = self.loggedIn
+
+        Task {
+            guard let client = await DevCycleManager.shared.clientAsync else { return }
+            if isCurrentlyLoggedIn {
+                do {
+                    try await client.resetUser()
+                    self.setLoginButtonTitle(false)
+                    print("Reset User!")
+                } catch {
+                    print("Error resetting user: \(error)")
                 }
-                if (variable2.value == 1) {
-                    print("Evaluated num_key_defaulted")
-                } else {
-                    print("Defaulted num_key_defaulted")
+            } else {
+                do {
+                    let user = try DevCycleUser.builder()
+                        .userId("my-user1")
+                        .email("my-email@email.com")
+                        .country("CA")
+                        .name("Ash Ketchum")
+                        .language("EN")
+                        .customData([
+                            "customkey": "customValue"
+                        ])
+                        .privateCustomData([
+                            "customkey2": "customValue2"
+                        ])
+                        .build()
+                    try await client.identifyUser(user: user)
+                    self.setLoginButtonTitle(true)
+                    print("Logged in as User: \(String(describing: user.userId))!")
+                    let numKeyValue = client.variableValue(key: "num_key", defaultValue: 0)
+                    print("Num_key is \(numKeyValue)!")
+                    let numKeyDefaultedValue = client.variableValue(
+                        key: "num_key_defaulted", defaultValue: 0)
+                    print("Num_key_defaulted is \(numKeyDefaultedValue)!")
+                } catch {
+                    print("Error identifying user: \(error)")
                 }
             }
         }
     }
-    
+
     @IBAction func track(_ sender: Any) {
-        guard let client = self.client else { return }
-        let event = try! DevCycleEvent.builder()
-                                 .type("my_event")
-                                 .target("my_target")
-                                 .value(3)
-                                 .metaData([ "key": "value" ])
-                                 .clientDate(Date())
-                                 .build()
-        client.track(event)
-        print("Tracked event to DevCycle")
+        Task {
+            guard let client = await DevCycleManager.shared.clientAsync else { return }
+            let event = try! DevCycleEvent.builder()
+                .type("my_event")
+                .target("my_target")
+                .value(3)
+                .metaData(["key": "value"])
+                .clientDate(Date())
+                .build()
+            client.track(event)
+            print("Tracked event to DevCycle")
+        }
     }
-    
+
     @IBAction func logAllFeatures(_ sender: Any) {
         print("logAllFeatures Button Pressed")
-        guard let client = self.client else { return }
-        print("All Features: \(client.allFeatures())")
-        print("All Variables: \(client.allVariables())")
+        Task {
+            guard let client = await DevCycleManager.shared.clientAsync else { return }
+            print("All Features: \(client.allFeatures())")
+            print("All Variables: \(client.allVariables())")
+        }
     }
 }
-

--- a/Examples/DevCycle-MacOS-Example-App/Podfile
+++ b/Examples/DevCycle-MacOS-Example-App/Podfile
@@ -1,5 +1,5 @@
 # Uncomment the next line to define a global platform for your project
-platform :macos, '10.13'
+platform :macos, '10.15'
 
 target 'DevCycle-macOS-Example-App' do
   # Comment the next line if you don't want to use dynamic frameworks

--- a/Examples/DevCycle-iOS-Example-App-Swift/DevCycle-iOS-Example-App-Swift/AppDelegate.swift
+++ b/Examples/DevCycle-iOS-Example-App-Swift/DevCycle-iOS-Example-App-Swift/AppDelegate.swift
@@ -4,40 +4,52 @@
 //
 //
 
-import UIKit
 import DevCycle
+import UIKit
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        // TODO: Set SDK KEY in DevCycleManager.swift
-        
-        // create anonymous user
-        let user = try? DevCycleUser.builder()
-                               .isAnonymous(true)
-                               .build()
-        
-        // initialize DevCycle
-        if let user = user {
-            DevCycleManager.shared.initialize(user: user)
+    func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
+    ) -> Bool {
+        do {
+            // TODO: Set SDK Key in DevCycleManager.swift
+
+            // Insert code here to initialize your application
+            // create anonymous user
+            let user = try DevCycleUser.builder()
+                .isAnonymous(true)
+                .build()
+            Task {
+                // Initialize DevCycle
+                await DevCycleManager.shared.initialize(user: user)
+            }
+        } catch {
+            fatalError("Failed to build DevCycleUser: \(error)")
         }
-        
         return true
     }
 
     // MARK: UISceneSession Lifecycle
 
-    func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
+    func application(
+        _ application: UIApplication,
+        configurationForConnecting connectingSceneSession: UISceneSession,
+        options: UIScene.ConnectionOptions
+    ) -> UISceneConfiguration {
         // Called when a new scene session is being created.
         // Use this method to select a configuration to create the new scene with.
-        return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
+        return UISceneConfiguration(
+            name: "Default Configuration", sessionRole: connectingSceneSession.role)
     }
 
-    func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
+    func application(
+        _ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>
+    ) {
         // Called when the user discards a scene session.
         // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
         // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
     }
 }
-

--- a/Examples/DevCycle-iOS-Example-App-Swift/DevCycle-iOS-Example-App-Swift/DevCycleManager.swift
+++ b/Examples/DevCycle-iOS-Example-App-Swift/DevCycle-iOS-Example-App-Swift/DevCycleManager.swift
@@ -12,24 +12,28 @@ struct DevCycleKeys {
 }
 
 class DevCycleManager {
-
-    var client: DevCycleClient?
+    private var client: DevCycleClient?
+    private var initializationTask: Task<DevCycleClient?, Never>?
     static let shared = DevCycleManager()
 
     func initialize(user: DevCycleUser) {
-        let options = DevCycleOptions.builder()
-            // .logLevel(.debug)
-            .build()
-
-        guard
-            let client = try? DevCycleClient.builder()
+        guard initializationTask == nil else { return }
+        initializationTask = Task {
+            let options = DevCycleOptions.builder()
+                .build()
+            let client = try? await DevCycleClient.builder()
                 .sdkKey(DevCycleKeys.DEVELOPMENT)
                 .user(user)
                 .options(options)
-                .build(onInitialized: nil)
-        else {
-            return
+                .build()
+            self.client = client
+            return client
         }
-        self.client = client
+    }
+
+    var clientAsync: DevCycleClient? {
+        get async {
+            return await initializationTask?.value
+        }
     }
 }

--- a/Examples/DevCycle-iOS-Example-App-Swift/DevCycle-iOS-Example-App-Swift/ViewController.swift
+++ b/Examples/DevCycle-iOS-Example-App-Swift/DevCycle-iOS-Example-App-Swift/ViewController.swift
@@ -4,33 +4,36 @@
 //
 //
 
-import UIKit
 import DevCycle
+import UIKit
 
 class ViewController: UIViewController {
 
     @IBOutlet weak var titleHeader: UILabel!
     @IBOutlet weak var loginButton: UIButton!
-    
+
     var loggedIn: Bool = false
-    var client: DevCycleClient?
     var titleHeaderVar: DVCVariable<String>?
     var loginCtaVar: DVCVariable<String>?
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
-        // Do any additional setup after loading the view.
-        self.client = DevCycleManager.shared.client
-        self.loginCtaVar = client?.variable(key: "login-cta-copy", defaultValue: "Log").onUpdate(handler: { value in
-            self.setLoginButtonTitle(self.loggedIn)
-        })
-        self.titleHeaderVar = client?.variable(key: "title-header-copy", defaultValue: "DevCycle iOS Example App").onUpdate(handler: { value in
+        Task {
+            guard let client = await DevCycleManager.shared.clientAsync else { return }
+            self.loginCtaVar = client.variable(key: "login-cta-copy", defaultValue: "Log")
+                .onUpdate(handler: { value in
+                    self.setLoginButtonTitle(self.loggedIn)
+                })
+            self.titleHeaderVar = client.variable(
+                key: "title-header-copy", defaultValue: "DevCycle iOS Example App"
+            ).onUpdate(handler: { value in
+                self.setTitleHeader()
+            })
             self.setTitleHeader()
-        })
-        self.setTitleHeader()
-        self.setLoginButtonTitle(false)
+            self.setLoginButtonTitle(false)
+        }
     }
-    
+
     func setTitleHeader() {
         guard let titleHeaderVar = self.titleHeaderVar else {
             return
@@ -45,69 +48,70 @@ class ViewController: UIViewController {
         self.loggedIn = bool
         self.loginButton.setTitle("\(loginCta.value) \(self.loggedIn ? "out" : "in")", for: .normal)
     }
-    
+
     @IBAction func loginButtonPressed(_ sender: Any) {
-        guard let client = self.client else { return }
-        if (self.loggedIn) {
-            try? client.resetUser { [weak self] error, variables in
-                guard let self = self else { return }
-                self.setLoginButtonTitle(false)
-                print("Reset User!")
-                print("Variables: \(String(describing: variables))")
-            }
-        } else {
-            let user = try? DevCycleUser.builder()
-                              .userId("my-user1")
-                              .email("my-email@email.com")
-                              .country("CA")
-                              .name("Ash Ketchum")
-                              .language("EN")
-                              .customData([
-                                "customkey": "customValue"
-                              ])
-                              .privateCustomData([
-                                "customkey2": "customValue2"
-                              ])
-                              .build()
-            try? client.identifyUser(user: user!) { [weak self] error, variables in
-                guard let self = self else { return }
-                self.setLoginButtonTitle(true)
-                print("Logged in as User: \(String(describing: user?.userId))!")
-                print("Variables: \(String(describing: variables))")
-                
-                let variable = client.variable(key: "num_key", defaultValue: 0)
-                let variable2 = client.variable(key: "num_key_defaulted", defaultValue: 0)
-                if (variable.value == 1) {
-                    print("Num_key is 1!")
-                } else {
-                    print("Num_key is 0!")
+        Task {
+            guard let client = await DevCycleManager.shared.clientAsync else { return }
+            if self.loggedIn {
+                do {
+                    try await client.resetUser()
+                    self.setLoginButtonTitle(false)
+                    print("Reset User!")
+                } catch {
+                    print("Error resetting user: \(error)")
                 }
-                if (variable2.value == 1) {
-                    print("Evaluated num_key_defaulted")
-                } else {
-                    print("Defaulted num_key_defaulted")
+            } else {
+                do {
+                    let user = try DevCycleUser.builder()
+                        .userId("my-user1")
+                        .email("my-email@email.com")
+                        .country("CA")
+                        .name("Ash Ketchum")
+                        .language("EN")
+                        .customData([
+                            "customkey": "customValue"
+                        ])
+                        .privateCustomData([
+                            "customkey2": "customValue2"
+                        ])
+                        .build()
+                    try await client.identifyUser(user: user)
+                    self.setLoginButtonTitle(true)
+                    print("Logged in as User: \(String(describing: user.userId))!")
+
+                    let numKeyValue = client.variableValue(key: "num_key", defaultValue: 0)
+                    print("Num_key is \(numKeyValue)!")
+
+                    let numKeyDefaultedValue = client.variableValue(
+                        key: "num_key_defaulted", defaultValue: 0)
+                    print("Num_key_defaulted is \(numKeyDefaultedValue)!")
+                } catch {
+                    print("Error identifying user: \(error)")
                 }
             }
         }
     }
-    
+
     @IBAction func track(_ sender: Any) {
-        guard let client = self.client else { return }
-        let event = try! DevCycleEvent.builder()
-                                 .type("my_event")
-                                 .target("my_target")
-                                 .value(3)
-                                 .metaData([ "key": "value" ])
-                                 .clientDate(Date())
-                                 .build()
-        client.track(event)
-        print("Tracked event to DevCycle")
+        Task {
+            guard let client = await DevCycleManager.shared.clientAsync else { return }
+            let event = try! DevCycleEvent.builder()
+                .type("my_event")
+                .target("my_target")
+                .value(3)
+                .metaData(["key": "value"])
+                .clientDate(Date())
+                .build()
+            client.track(event)
+            print("Tracked event to DevCycle")
+        }
     }
-    
+
     @IBAction func logAllFeatures(_ sender: Any) {
-        guard let client = self.client else { return }
-        print("All Features: \(client.allFeatures())")
-        print("All Variables: \(client.allVariables())")
+        Task {
+            guard let client = await DevCycleManager.shared.clientAsync else { return }
+            print("All Features: \(client.allFeatures())")
+            print("All Variables: \(client.allVariables())")
+        }
     }
 }
-

--- a/Examples/DevCycle-tvOS-Example-App/DevCycle-tvOS-Example-App/AppDelegate.swift
+++ b/Examples/DevCycle-tvOS-Example-App/DevCycle-tvOS-Example-App/AppDelegate.swift
@@ -3,24 +3,32 @@
 //  DevCycle-tvOS-Example-App
 //
 
-import UIKit
 import DevCycle
+import UIKit
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?
 
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        
-        // create anonymous user
-        let user = try? DevCycleUser.builder()
-                               .isAnonymous(true)
-                               .build()
-        
-        // initialize DevCycle
-        if let user = user {
-            DevCycleManager.shared.initialize(user: user)
+    func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
+    ) -> Bool {
+        do {
+            // TODO: Set SDK Key in DevCycleManager.swift
+
+            // Insert code here to initialize your application
+            // create anonymous user
+            let user = try DevCycleUser.builder()
+                .isAnonymous(true)
+                .build()
+            Task {
+                // Initialize DevCycle
+                await DevCycleManager.shared.initialize(user: user)
+            }
+        } catch {
+            fatalError("Failed to build DevCycleUser: \(error)")
         }
         return true
     }

--- a/Examples/DevCycle-tvOS-Example-App/DevCycle-tvOS-Example-App/ViewController.swift
+++ b/Examples/DevCycle-tvOS-Example-App/DevCycle-tvOS-Example-App/ViewController.swift
@@ -3,33 +3,36 @@
 //  DevCycle-tvOS-Example-App
 //
 
-import UIKit
 import DevCycle
+import UIKit
 
 class ViewController: UIViewController {
 
     @IBOutlet weak var titleHeader: UILabel!
     @IBOutlet weak var loginButton: UIButton!
-    
+
     var loggedIn: Bool = false
-    var client: DevCycleClient?
     var titleHeaderVar: DVCVariable<String>?
     var loginCtaVar: DVCVariable<String>?
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
-        // Do any additional setup after loading the view.
-        self.client = DevCycleManager.shared.client
-        self.loginCtaVar = client?.variable(key: "login-cta-copy", defaultValue: "Log").onUpdate(handler: { value in
-            self.setLoginButtonTitle(self.loggedIn)
-        })
-        self.titleHeaderVar = client?.variable(key: "title-header-copy", defaultValue: "DevCycle iOS Example App").onUpdate(handler: { value in
+        Task {
+            guard let client = await DevCycleManager.shared.clientAsync else { return }
+            self.loginCtaVar = client.variable(key: "login-cta-copy", defaultValue: "Log")
+                .onUpdate(handler: { value in
+                    self.setLoginButtonTitle(self.loggedIn)
+                })
+            self.titleHeaderVar = client.variable(
+                key: "title-header-copy", defaultValue: "DevCycle iOS Example App"
+            ).onUpdate(handler: { value in
+                self.setTitleHeader()
+            })
             self.setTitleHeader()
-        })
-        self.setTitleHeader()
-        self.setLoginButtonTitle(false)
+            self.setLoginButtonTitle(false)
+        }
     }
-    
+
     func setTitleHeader() {
         guard let titleHeaderVar = self.titleHeaderVar else {
             return
@@ -44,69 +47,71 @@ class ViewController: UIViewController {
         self.loggedIn = bool
         self.loginButton.setTitle("\(loginCta.value) \(self.loggedIn ? "out" : "in")", for: .normal)
     }
-    
+
     @IBAction func loginButtonPressed(_ sender: Any) {
-        guard let client = self.client else { return }
-        if (self.loggedIn) {
-            try? client.resetUser { [weak self] error, variables in
-                guard let self = self else { return }
-                self.setLoginButtonTitle(false)
-                print("Reset User!")
-                print("Variables: \(String(describing: variables))")
-            }
-        } else {
-            let user = try? DevCycleUser.builder()
-                              .userId("my-user1")
-                              .email("my-email@email.com")
-                              .country("CA")
-                              .name("Ash Ketchum")
-                              .language("EN")
-                              .customData([
-                                "customkey": "customValue"
-                              ])
-                              .privateCustomData([
-                                "customkey2": "customValue2"
-                              ])
-                              .build()
-            try? client.identifyUser(user: user!) { [weak self] error, variables in
-                guard let self = self else { return }
-                self.setLoginButtonTitle(true)
-                print("Logged in as User: \(String(describing: user?.userId))!")
-                print("Variables: \(String(describing: variables))")
-                
-                let variable = client.variable(key: "num_key", defaultValue: 0)
-                let variable2 = client.variable(key: "num_key_defaulted", defaultValue: 0)
-                if (variable.value == 1) {
-                    print("Num_key is 1!")
-                } else {
-                    print("Num_key is 0!")
+        Task {
+            guard let client = await DevCycleManager.shared.clientAsync else { return }
+            if self.loggedIn {
+                do {
+                    try await client.resetUser()
+                    self.setLoginButtonTitle(false)
+                    print("Reset User!")
+                } catch {
+                    print("Error resetting user: \(error)")
                 }
-                if (variable2.value == 1) {
-                    print("Evaluated num_key_defaulted")
-                } else {
-                    print("Defaulted num_key_defaulted")
+            } else {
+                do {
+                    let user = try DevCycleUser.builder()
+                        .userId("my-user1")
+                        .email("my-email@email.com")
+                        .country("CA")
+                        .name("Ash Ketchum")
+                        .language("EN")
+                        .customData([
+                            "customkey": "customValue"
+                        ])
+                        .privateCustomData([
+                            "customkey2": "customValue2"
+                        ])
+                        .build()
+                    try await client.identifyUser(user: user)
+                    self.setLoginButtonTitle(true)
+                    print("Logged in as User: \(String(describing: user.userId))!")
+
+                    let numKeyValue = client.variableValue(key: "num_key", defaultValue: 0)
+                    print("Num_key is \(numKeyValue)!")
+
+                    let numKeyDefaultedValue = client.variableValue(
+                        key: "num_key_defaulted", defaultValue: 0)
+                    print("Num_key_defaulted is \(numKeyDefaultedValue)!")
+                } catch {
+                    print("Error identifying user: \(error)")
                 }
             }
         }
     }
-    
+
     @IBAction func track(_ sender: Any) {
-        guard let client = self.client else { return }
-        let event = try! DevCycleEvent.builder()
-                                 .type("my_event")
-                                 .target("my_target")
-                                 .value(3)
-                                 .metaData([ "key": "value" ])
-                                 .clientDate(Date())
-                                 .build()
-        client.track(event)
-        print("Tracked event to DevCycle")
+        Task {
+            guard let client = await DevCycleManager.shared.clientAsync else { return }
+            let event = try! DevCycleEvent.builder()
+                .type("my_event")
+                .target("my_target")
+                .value(3)
+                .metaData(["key": "value"])
+                .clientDate(Date())
+                .build()
+            client.track(event)
+            print("Tracked event to DevCycle")
+        }
     }
-    
+
     @IBAction func logAllFeatures(_ sender: Any) {
-        guard let client = self.client else { return }
-        print("All Features: \(client.allFeatures())")
-        print("All Variables: \(client.allVariables())")
+        Task {
+            guard let client = await DevCycleManager.shared.clientAsync else { return }
+            print("All Features: \(client.allFeatures())")
+            print("All Variables: \(client.allVariables())")
+        }
     }
-    
+
 }

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source "https://rubygems.org"
 
 gem "fastlane"
+gem "abbrev"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,22 +5,24 @@ GEM
       base64
       nkf
       rexml
+    abbrev (0.1.2)
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
     artifactory (3.0.17)
     atomos (0.1.3)
     aws-eventstream (1.3.2)
-    aws-partitions (1.1066.0)
-    aws-sdk-core (3.220.1)
+    aws-partitions (1.1106.0)
+    aws-sdk-core (3.224.0)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.992.0)
       aws-sigv4 (~> 1.9)
       base64
       jmespath (~> 1, >= 1.6.1)
-    aws-sdk-kms (1.99.0)
+      logger
+    aws-sdk-kms (1.101.0)
       aws-sdk-core (~> 3, >= 3.216.0)
       aws-sigv4 (~> 1.5)
-    aws-sdk-s3 (1.182.0)
+    aws-sdk-s3 (1.186.1)
       aws-sdk-core (~> 3, >= 3.216.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.5)
@@ -69,7 +71,7 @@ GEM
     faraday_middleware (1.2.1)
       faraday (~> 1.0)
     fastimage (2.4.0)
-    fastlane (2.227.0)
+    fastlane (2.227.2)
       CFPropertyList (>= 2.3, < 4.0.0)
       addressable (>= 2.8, < 3.0.0)
       artifactory (~> 3.0)
@@ -109,7 +111,7 @@ GEM
       tty-spinner (>= 0.8.0, < 1.0.0)
       word_wrap (~> 1.0.0)
       xcodeproj (>= 1.13.0, < 2.0.0)
-      xcpretty (~> 0.4.0)
+      xcpretty (~> 0.4.1)
       xcpretty-travis-formatter (>= 0.0.3, < 2.0.0)
     fastlane-sirp (1.0.0)
       sysrandom (~> 1.0)
@@ -156,9 +158,10 @@ GEM
     httpclient (2.9.0)
       mutex_m
     jmespath (1.6.2)
-    json (2.10.2)
+    json (2.12.0)
     jwt (2.10.1)
       base64
+    logger (1.7.0)
     mini_magick (4.13.2)
     mini_mime (1.1.5)
     multi_json (1.15.0)
@@ -170,7 +173,7 @@ GEM
     optparse (0.6.0)
     os (1.1.4)
     plist (3.7.2)
-    public_suffix (6.0.1)
+    public_suffix (6.0.2)
     rake (13.2.1)
     representable (3.2.0)
       declarative (< 0.1.0)
@@ -182,7 +185,7 @@ GEM
     ruby2_keywords (0.0.5)
     rubyzip (2.4.1)
     security (0.1.5)
-    signet (0.19.0)
+    signet (0.20.0)
       addressable (~> 2.8)
       faraday (>= 0.17.5, < 3.a)
       jwt (>= 1.5, < 3.0)
@@ -209,19 +212,21 @@ GEM
       colored2 (~> 3.1)
       nanaimo (~> 0.4.0)
       rexml (>= 3.3.6, < 4.0)
-    xcpretty (0.4.0)
+    xcpretty (0.4.1)
       rouge (~> 3.28.0)
     xcpretty-travis-formatter (1.0.1)
       xcpretty (~> 0.2, >= 0.0.7)
 
 PLATFORMS
   arm64-darwin-23
+  arm64-darwin-24
   universal-darwin-22
   x86_64-darwin-20
   x86_64-linux
 
 DEPENDENCIES
+  abbrev
   fastlane
 
 BUNDLED WITH
-   2.2.32
+   2.6.8


### PR DESCRIPTION
Added comments where the main changes are as a lot of these changes are just auto formatting changes.

- Added async methods to all public methods in DevCycleUser
- Updated tests to test new async methods and fix some test issues.
- Updated anon user id caching logic

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
