### PR TITLE
chore: run flutter sdk update action after cocoapods publish

### DIFF
--- a/.github/workflows/publish-pod.yml
+++ b/.github/workflows/publish-pod.yml
@@ -27,3 +27,32 @@ jobs:
           COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
         run: |
           pod trunk push DevCycle.podspec --allow-warnings --verbose
+
+  wait-before-flutter-update:
+    runs-on: ubuntu-latest
+    needs: publish-cocoapods
+    if: startsWith(github.ref, 'refs/tags/')
+    steps:
+      - name: Wait for CocoaPods to update
+        run: |
+          # CocoaPods can be slow to update after publishing, so we wait 1 minute
+          sleep 60
+
+  update-flutter-sdk:
+    runs-on: ubuntu-latest
+    needs: wait-before-flutter-update
+    steps:
+      - name: Get latest tag
+        id: get-tag
+        run: |
+          # Get the latest tag and strip the 'v' prefix
+          LATEST_TAG=$(git ls-remote --tags --sort=version:refname https://github.com/DevCycleHQ/ios-client-sdk.git | tail -n1 | sed 's/.*\///;s/v//')
+          echo "version=$LATEST_TAG" >> $GITHUB_OUTPUT
+
+      - name: Trigger Flutter SDK Update
+        uses: benc-uk/workflow-dispatch@v1
+        with:
+          workflow: update-ios-sdk-version.yaml
+          repo: DevCycleHQ/flutter-client-sdk
+          token: ${{ secrets.AUTOMATION_USER_TOKEN }}
+          inputs: '{"target-version": "${{ steps.get-tag.outputs.version }}"}'


### PR DESCRIPTION
- Call the `update-ios-sdk-version` action on the flutter-client-sdk repo after cocoapods publish to create a PR in that repo to update its iOS SDK version


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
