### PR TITLE
fix: move permissions to job level

### DIFF
--- a/.github/workflows/publish-pod.yml
+++ b/.github/workflows/publish-pod.yml
@@ -51,6 +51,9 @@ jobs:
   update-flutter-sdk:
     uses: DevCycleHQ/flutter-client-sdk/.github/workflows/update-ios-sdk-version.yaml@main
     needs: wait-before-flutter-update
+    permissions:
+      contents: write
+      pull-requests: write
     with:
       target-version: ${{ needs.wait-before-flutter-update.outputs.version }}
     secrets: inherit


### PR DESCRIPTION



<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
