### PR TITLE
fix: remove unsafe casts to prevent runtime exceptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,5 @@ fastlane/fastlane-buildlog
 iOSInjectionProject/
 .DS_Store
 *.DS_Store
+
+**/contents.xcworkspacedata

--- a/DevCycle.xcodeproj/project.pbxproj
+++ b/DevCycle.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		52E693EA27567E2600B52375 /* DevCycleService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52E693E927567E2600B52375 /* DevCycleService.swift */; };
 		52E693ED2756816A00B52375 /* DVCConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52E693EC2756816A00B52375 /* DVCConfig.swift */; };
 		52E693F62758032500B52375 /* DevCycleServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52E693F52758032500B52375 /* DevCycleServiceTests.swift */; };
+		52E8C1F12DF87C5A0044783D /* DevCycleEventTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52E8C1F02DF87C560044783D /* DevCycleEventTests.swift */; };
 		D9341C12276967DE00BC753F /* DevCycleEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9341C11276967DE00BC753F /* DevCycleEvent.swift */; };
 		D9341C14276A3C8A00BC753F /* ObjCDevCycleEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9341C13276A3C8A00BC753F /* ObjCDevCycleEvent.swift */; };
 		E66CF1C82901E9C7008734FD /* LDSwiftEventSource.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = E66CF1C72901E9C7008734FD /* LDSwiftEventSource.xcframework */; };
@@ -127,6 +128,7 @@
 		52E693E927567E2600B52375 /* DevCycleService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DevCycleService.swift; sourceTree = "<group>"; };
 		52E693EC2756816A00B52375 /* DVCConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DVCConfig.swift; sourceTree = "<group>"; };
 		52E693F52758032500B52375 /* DevCycleServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DevCycleServiceTests.swift; sourceTree = "<group>"; };
+		52E8C1F02DF87C560044783D /* DevCycleEventTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DevCycleEventTests.swift; sourceTree = "<group>"; };
 		D9341C11276967DE00BC753F /* DevCycleEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DevCycleEvent.swift; sourceTree = "<group>"; };
 		D9341C13276A3C8A00BC753F /* ObjCDevCycleEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjCDevCycleEvent.swift; sourceTree = "<group>"; };
 		E66CF1C72901E9C7008734FD /* LDSwiftEventSource.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = LDSwiftEventSource.xcframework; path = Carthage/Build/LDSwiftEventSource.xcframework; sourceTree = "<group>"; };
@@ -201,6 +203,7 @@
 		5264A78C2768E87C00FEDB43 /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				52E8C1F02DF87C560044783D /* DevCycleEventTests.swift */,
 				5268DB68275020D900D17A40 /* DevCycleUserTest.swift */,
 				524F4E61276D20A500CB9069 /* DVCVariableTests.swift */,
 				5276C9F1275E6E0D00B9A324 /* DevCycleOptionsTest.swift */,
@@ -463,6 +466,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				529F0CA52774D6BE0075AAB4 /* URLSessionMock.swift in Sources */,
+				52E8C1F12DF87C5A0044783D /* DevCycleEventTests.swift in Sources */,
 				52133B2028DDFB260007691D /* RequestConsolidatorTests.swift in Sources */,
 				5276C9F2275E6E0D00B9A324 /* DevCycleOptionsTest.swift in Sources */,
 				5264A7902768E9F400FEDB43 /* UserConfigTests.swift in Sources */,

--- a/DevCycle/DevCycleClient.swift
+++ b/DevCycle/DevCycleClient.swift
@@ -273,9 +273,11 @@ public class DevCycleClient {
                     return
                 }
                 do {
-                    let messageDictionary =
+                    guard let messageDictionary =
                         try JSONSerialization.jsonObject(
-                            with: messageData, options: .fragmentsAllowed) as! [String: Any]
+                            with: messageData, options: .fragmentsAllowed) as? [String: Any] else {
+                        throw SSEMessage.SSEMessageError.messageError("Error serializing sse message to JSON")
+                    }
                     let sseMessage = try SSEMessage(from: messageDictionary)
                     if sseMessage.data.type == nil || sseMessage.data.type == "refetchConfig" {
                         if self?.config?.userConfig?.etag == nil

--- a/DevCycle/Models/DevCycleEvent.swift
+++ b/DevCycle/Models/DevCycleEvent.swift
@@ -37,22 +37,22 @@ public class DevCycleEvent {
             return self
         }
         
-        public func target(_ target: String) -> EventBuilder {
+        public func target(_ target: String?) -> EventBuilder {
             self.event.target = target
             return self
         }
         
-        public func clientDate(_ clientDate: Date) -> EventBuilder {
+        public func clientDate(_ clientDate: Date?) -> EventBuilder {
             self.event.clientDate = clientDate
             return self
         }
         
-        public func value(_ value: Double) -> EventBuilder {
+        public func value(_ value: Double?) -> EventBuilder {
             self.event.value = value
             return self
         }
         
-        public func metaData(_ metaData: [String:Any]) -> EventBuilder {
+        public func metaData(_ metaData: [String:Any]?) -> EventBuilder {
             self.event.metaData = metaData
             return self
         }

--- a/DevCycle/Models/UserConfig.swift
+++ b/DevCycle/Models/UserConfig.swift
@@ -11,6 +11,7 @@ enum UserConfigError: Error {
     case MissingProperty(String)
     case InvalidVariableType(String)
     case InvalidProperty(String)
+    case InvalidJson(String)
 }
 
 public struct UserConfig {

--- a/DevCycle/Networking/DevCycleService.swift
+++ b/DevCycle/Networking/DevCycleService.swift
@@ -164,10 +164,14 @@ class DevCycleService: DevCycleServiceProtocol {
                 // Guard below checks if statusCode exists or not in the response body.
                 // Only API Errors (http status codes of 4xx/5xx) have the statusCode in the response body, successful API Requests (http status codes of 2xx/3xx) calls will not.
                 guard responseDataJson["statusCode"] == nil else {
-                    let status = responseDataJson["statusCode"] as! Int
-                    var errorResponse: String
+                    guard let status = responseDataJson["statusCode"] as? Int else {
+                        return
+                    }
+                    var errorResponse: String = ""
                     if (responseDataJson["message"] is [String]) {
-                        errorResponse = (responseDataJson["message"] as! [String]).joined(separator: ", ")
+                        if let errorArray = (responseDataJson["message"] as? [String]) {
+                            errorResponse = errorArray.joined(separator: ", ")
+                        }
                     } else {
                         errorResponse = String(describing: responseDataJson["message"])
                     }

--- a/DevCycle/ObjC/ObjCDevCycleEvent.swift
+++ b/DevCycle/ObjC/ObjCDevCycleEvent.swift
@@ -49,10 +49,10 @@ public class ObjCDevCycleEvent: NSObject {
             eventBuilder = eventBuilder.clientDate(eventDate as Date)
         }
         if let eventValue = self.value {
-            eventBuilder = eventBuilder.value(eventValue as! Double)
+            eventBuilder = eventBuilder.value(eventValue as? Double)
         }
         if let eventMetaData = self.metaData {
-            eventBuilder = eventBuilder.metaData(eventMetaData as! [String : Any])
+            eventBuilder = eventBuilder.metaData(eventMetaData as? [String : Any])
         }
         
         do {

--- a/DevCycle/SSEConnection.swift
+++ b/DevCycle/SSEConnection.swift
@@ -94,6 +94,7 @@ class Handler: EventHandler {
 public struct SSEMessage {
     enum SSEMessageError: Error, Equatable {
         case initError(String)
+        case messageError(String)
     }
     struct Data {
         var etag: String?

--- a/DevCycle/Utils/ProcessConfig.swift
+++ b/DevCycle/Utils/ProcessConfig.swift
@@ -13,7 +13,9 @@ internal func processConfig(_ responseData: Data?) -> UserConfig? {
         return nil
     }
     do {
-        let dictionary = try JSONSerialization.jsonObject(with: data, options: .fragmentsAllowed) as! [String:Any]
+        guard let dictionary = try JSONSerialization.jsonObject(with: data, options: .fragmentsAllowed) as? [String:Any] else {
+            throw UserConfigError.InvalidJson("Error with serializing config data to JSON")
+        }
         return try UserConfig(from: dictionary)
     } catch {
         Log.error("Failed to decode config: \(error)", tags: ["service", "request"])

--- a/DevCycle/Utils/RequestConsolidator.swift
+++ b/DevCycle/Utils/RequestConsolidator.swift
@@ -60,7 +60,7 @@ class RequestConsolidator {
 
     func makeLastRequestInQueue(user: DevCycleUser, complete: (() -> Void)?) {
         guard let lastRequest = self.requestCallbacks.last?.request else {
-            print("No last request to make in queue")
+            Log.debug("No last request to make in queue")
             return
         }
         service.makeRequest(request: lastRequest) { response in

--- a/DevCycleTests/Models/DevCycleEventTests.swift
+++ b/DevCycleTests/Models/DevCycleEventTests.swift
@@ -1,0 +1,87 @@
+//
+//  DevCycleEventTests.swift
+//  DevCycleTests
+//
+//
+
+import XCTest
+
+@testable import DevCycle
+
+class DevCycleEventTests: XCTestCase {
+    
+    func testCreateEventWithMinimumRequiredFields() throws {
+        // Test creating an event with just the required type field
+        let event = try DevCycleEvent.builder()
+            .type("test_event")
+            .build()
+        
+        XCTAssertEqual(event.type, "test_event")
+        XCTAssertNil(event.target)
+        XCTAssertNil(event.clientDate)
+        XCTAssertNil(event.value)
+        XCTAssertNil(event.metaData)
+    }
+    
+    func testCreateEventWithAllFields() throws {
+        // Test creating an event with all fields populated
+        let date = Date()
+        let metaData: [String: Any] = ["key1": "value1", "key2": 123, "key3": true]
+        
+        let event = try DevCycleEvent.builder()
+            .type("test_event")
+            .target("test_target")
+            .clientDate(date)
+            .value(42.5)
+            .metaData(metaData)
+            .build()
+        
+        XCTAssertEqual(event.type, "test_event")
+        XCTAssertEqual(event.target, "test_target")
+        XCTAssertEqual(event.clientDate, date)
+        XCTAssertEqual(event.value, 42.5)
+        XCTAssertEqual(event.metaData?["key1"] as? String, "value1")
+        XCTAssertEqual(event.metaData?["key2"] as? Int, 123)
+        XCTAssertEqual(event.metaData?["key3"] as? Bool, true)
+    }
+    
+    func testCreateEventWithMissingType() {
+        // Test that creating an event without a type throws an error
+        XCTAssertThrowsError(try DevCycleEvent.builder().build()) { error in
+            XCTAssertEqual(error as? EventError, EventError.MissingEventType)
+        }
+    }
+    
+    func testCreateEventWithBuilderReuse() throws {
+        // Test that the builder can be reused after building an event
+        let builder = DevCycleEvent.builder()
+        
+        let event1 = try builder
+            .type("event1")
+            .build()
+        
+        let event2 = try builder
+            .type("event2")
+            .build()
+        
+        XCTAssertEqual(event1.type, "event1")
+        XCTAssertEqual(event2.type, "event2")
+    }
+    
+    func testCreateEventWithNilValues() throws {
+        // Test creating an event with explicit nil values
+        let event = try DevCycleEvent.builder()
+            .type("test_event")
+            .target(nil)
+            .clientDate(nil)
+            .value(nil)
+            .metaData(nil)
+            .build()
+        
+        XCTAssertEqual(event.type, "test_event")
+        XCTAssertNil(event.target)
+        XCTAssertNil(event.clientDate)
+        XCTAssertNil(event.value)
+        XCTAssertNil(event.metaData)
+    }
+}

--- a/DevCycleTests/Networking/DevCycleServiceTests.swift
+++ b/DevCycleTests/Networking/DevCycleServiceTests.swift
@@ -81,6 +81,12 @@ class DevCycleServiceTests: XCTestCase {
         let config = processConfig(data)
         XCTAssertNil(config)
     }
+    
+    func testProcessConfigReturnsErrorIfInvalidJson() throws {
+        let data = "{".data(using: .utf8)
+        let config = processConfig(data)
+        XCTAssertNil(config)
+    }
 
     func testFlushingEvents() {
         let service = MockDevCycleService()


### PR DESCRIPTION
# Changes

- replaced all instances of unsafe casting `as!` 
- added test file for DevCycleEvent

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
