### PR TITLE
fix: add sdk version to cache keys for configs

### DIFF
--- a/DevCycle/Models/Cache.swift
+++ b/DevCycle/Models/Cache.swift
@@ -42,7 +42,6 @@ class CacheService: CacheServiceProtocol {
     init(configCacheTTL: Int = DEFAULT_CONFIG_CACHE_TTL) {
         self.configCacheTTL = configCacheTTL
         migrateLegacyCache()
-        clearDeprecatedCachedConfigs()
     }
 
     func setAnonUserId(anonUserId: String) {
@@ -133,7 +132,7 @@ class CacheService: CacheServiceProtocol {
         return baseKey
     }
 
-    private func clearDeprecatedCachedConfigs() {
+    private func cleanupDeprecatedCachedConfigs() {
         let deprecatedKeys: [String] = defaults.dictionaryRepresentation().keys.compactMap { key in
             // Only include keys that contain one of these patterns
             guard key.contains(CacheKeys.identifiedConfig) || key.contains(CacheKeys.anonymousConfig) else {
@@ -163,6 +162,9 @@ class CacheService: CacheServiceProtocol {
 
         // Clean up legacy config cache
         cleanupLegacyConfigCache()
+        
+        // Clean up config cache from other SDK versions
+        cleanupDeprecatedCachedConfigs()
     }
 
     private func cleanupLegacyUserCache() {

--- a/DevCycle/Models/Cache.swift
+++ b/DevCycle/Models/Cache.swift
@@ -18,9 +18,12 @@ protocol CacheServiceProtocol {
 
 class CacheService: CacheServiceProtocol {
     struct CacheKeys {
+        static let platform = PlatformDetails()
+        static let versionPrefix = "VERSION_\(platform.sdkVersion)"
+        
         static let anonUserId = "ANONYMOUS_USER_ID"
-        static let identifiedConfigKey = "IDENTIFIED_CONFIG"
-        static let anonymousConfigKey = "ANONYMOUS_CONFIG"
+        static let identifiedConfigKey = "\(versionPrefix).IDENTIFIED_CONFIG"
+        static let anonymousConfigKey = "\(versionPrefix).ANONYMOUS_CONFIG"
         static let userIdSuffix = ".USER_ID"
         static let expiryDateSuffix = ".EXPIRY_DATE"
 


### PR DESCRIPTION
- fix: updates cache keys to include the SDK Version
- fix: cleanup cached configs from other SDK Versions
- chore: update tests for Cached Configs and Config Migrations