### PR TITLE
chore: add public static openFeatureEvalReason method to EvalReason

### DIFF
--- a/DevCycle/Models/UserConfig.swift
+++ b/DevCycle/Models/UserConfig.swift
@@ -232,6 +232,10 @@ public struct EvalReason {
     static func defaultReason(details: String) -> EvalReason {
         return EvalReason(reason: "DEFAULT", details: details)
     }
+
+    public static func openFeatureEvalReason(reason: String) -> EvalReason {
+        return EvalReason(reason: reason, details: "")
+    }
 }
 
 public typealias EvalMetaData = [String: Any]


### PR DESCRIPTION
- chore: adds a public static method for `openFeatureEvalReason` which accepts only the reason attribute and returns an EvalReason struct
  - this is being added to allow for testing of Eval Reasons from the DevCycle iOS OpenFeature provider