### PR TITLE
chore: wrap open feature reason in debug

### DIFF
--- a/DevCycle/Models/UserConfig.swift
+++ b/DevCycle/Models/UserConfig.swift
@@ -234,8 +234,8 @@ public struct EvalReason {
     }
 
     #if DEBUG
-    public static func openFeatureEvalReason(reason: String) -> EvalReason {
-        return EvalReason(reason: reason, details: "")
+    public static func createOFEvalReason(reason: String) -> EvalReason {
+        return EvalReason(reason: reason, details: "OpenFeature Testing")
     }
     #endif
 }


### PR DESCRIPTION
- chore: rename `openFeatureEvalReason` static method to `createOFEvalReason`
- chore: wrap `createOFEvalReason` in `#if DEBUG` to only allow the method to be used in Debug builds and not Release builds