### PR TITLE
fix: serialize userConfig access to prevent objc_retain crash

### DIFF
--- a/DevCycle/Models/DVCConfig.swift
+++ b/DevCycle/Models/DVCConfig.swift
@@ -9,18 +9,34 @@ import Foundation
 public class DVCConfig {
     var sdkKey: String
     var user: DevCycleUser
+    private let userConfigQueue = DispatchQueue(
+        label: "com.devcycle.userConfig", attributes: .concurrent)
+    private var _userConfig: UserConfig?
+
     var userConfig: UserConfig? {
-        didSet {
-            if let userConfig = self.userConfig {
-                NotificationCenter.default.post(
-                    name: Notification.Name(NotificationNames.NewUserConfig),
-                    object: self,
-                    userInfo: ["new-user-config" : userConfig]
-                )
+        get {
+            return userConfigQueue.sync { _userConfig }
+        }
+        set {
+            // Synchronously set using a barrier to preserve existing semantics
+            userConfigQueue.async(flags: .barrier) {
+                self._userConfig = newValue
+                if let userConfig = newValue {
+                    DispatchQueue.main.async {
+                        NotificationCenter.default.post(
+                            name: Notification.Name(NotificationNames.NewUserConfig),
+                            object: self,
+                            userInfo: ["new-user-config": userConfig]
+                        )
+                    }
+                }
             }
+            // Fence: wait for the async barrier write above to complete so subsequent reads
+            // observe the new value immediately (mirrors original didSet synchronous behavior).
+            userConfigQueue.sync {}
         }
     }
-    
+
     init(sdkKey: String, user: DevCycleUser) {
         self.sdkKey = sdkKey
         self.user = user

--- a/DevCycleTests/Utils/GetTestConfig.swift
+++ b/DevCycleTests/Utils/GetTestConfig.swift
@@ -6,10 +6,18 @@
 //
 
 import Foundation
+import XCTest
 
 func getConfigData(name: String, withExtension: String = "json") -> Data {
-    let bundle = Bundle(for: DevCycleClientTest.self)
-    let fileUrl = bundle.url(forResource: name, withExtension: withExtension)
-    let data = try! Data(contentsOf: fileUrl!)
+    #if SWIFT_PACKAGE
+        let bundle = Bundle.module
+    #else
+        let bundle = Bundle(for: DevCycleClientTest.self)
+    #endif
+    guard let fileUrl = bundle.url(forResource: name, withExtension: withExtension) else {
+        XCTFail("Missing test resource: \(name).\(withExtension)")
+        return Data()
+    }
+    let data = try! Data(contentsOf: fileUrl)
     return data
 }

--- a/Package.swift
+++ b/Package.swift
@@ -36,7 +36,11 @@ let package = Package(
             name: "DevCycleTests",
             dependencies: ["DevCycle"],
             path: "DevCycleTests",
-            exclude: ["ObjC"]
+            exclude: ["ObjC"],
+            resources: [
+                .process("Models/test_config.json"),
+                .process("Models/test_config_eval_reason.json"),
+            ]
         ),
         .testTarget(
             name: "DevCycleTests-ObjC",


### PR DESCRIPTION
-

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
