### PR TITLE
revert: restore network-first onClientInitialized contract

### DIFF
--- a/DevCycle/DevCycleClient.swift
+++ b/DevCycle/DevCycleClient.swift
@@ -140,9 +140,6 @@ public class DevCycleClient {
         #endif
     }
 
-    /// On a cache hit, returns synchronously from the persisted config and refreshes
-    /// in the background (observe via `onConfigUpdated(_:)`). On a cache miss, falls
-    /// back to the network-first path.
     func setup(service: DevCycleServiceProtocol, callback: ClientInitializedHandler? = nil) {
         guard let user = self.user else {
             callback?(ClientError.MissingSDKKeyOrUser)
@@ -150,41 +147,36 @@ public class DevCycleClient {
         }
         self.service = service
 
-        let cacheHit = self.useCachedConfigForUser(user: user)
+        let _ = self.useCachedConfigForUser(user: user)
 
-        if cacheHit {
-            self.deliverInitializationComplete(error: nil, callback: callback)
-            self.performBackgroundRefresh()
-        } else {
-            self.service?.getConfig(
-                user: user, enableEdgeDB: self.enableEdgeDB, extraParams: nil,
-                completion: { [weak self] config, error in
-                    guard let self = self else { return }
+        self.service?.getConfig(
+            user: user, enableEdgeDB: self.enableEdgeDB, extraParams: nil,
+            completion: { [weak self] config, error in
+                guard let self = self else { return }
 
-                    var finalError: Error? = error
+                var finalError: Error? = error
 
-                    if let error = error {
-                        Log.error("Error getting config: \(error)", tags: ["setup"])
+                if let error = error {
+                    Log.error("Error getting config: \(error)", tags: ["setup"])
 
-                        if self.config?.getUserConfig() != nil {
-                            Log.info("Using cached config due to network error")
-                            finalError = nil
-                        }
-                    } else if let config = config {
-                        Log.debug("Config: \(config)", tags: ["setup"])
-                        self.updateUserConfig(config)
-                    } else {
-                        Log.error("No config returned for setup", tags: ["setup"])
-                        finalError = ClientError.ConfigFetchFailed
+                    if self.config?.getUserConfig() != nil {
+                        Log.info("Using cached config due to network error")
+                        finalError = nil
                     }
+                } else if let config = config {
+                    Log.debug("Config: \(config)", tags: ["setup"])
+                    self.updateUserConfig(config)
+                } else {
+                    Log.error("No config returned for setup", tags: ["setup"])
+                    finalError = ClientError.ConfigFetchFailed
+                }
 
-                    if let config = config {
-                        self.syncUserToEdgeDBIfEnabled(user: user, config: config)
-                    }
+                if let config = config {
+                    self.syncUserToEdgeDBIfEnabled(user: user, config: config)
+                }
 
-                    self.deliverInitializationComplete(error: finalError, callback: callback)
-                })
-        }
+                self.deliverInitializationComplete(error: finalError, callback: callback)
+            })
 
         self.flushTimer = Timer.scheduledTimer(
             withTimeInterval: TimeInterval(self.flushEventsInterval),
@@ -265,43 +257,6 @@ public class DevCycleClient {
                 handler(error)
             }
             callback?(error)
-        }
-    }
-
-    private func performBackgroundRefresh() {
-        guard !self.closed, let user = self.lastIdentifiedUser else { return }
-        self.service?.getConfig(user: user, enableEdgeDB: self.enableEdgeDB, extraParams: nil) {
-            [weak self] config, error in
-            guard let self = self, !self.closed else { return }
-
-            guard user === self.lastIdentifiedUser else {
-                Log.warn(
-                    "Background refresh result is for stale user context, ignoring",
-                    tags: ["backgroundRefresh"])
-                return
-            }
-
-            if let error = error {
-                if self.isNonRetryableError(error) {
-                    // Keep cached values usable on non-retryable errors; only TTL evicts the cache.
-                    Log.error(
-                        "Background refresh failed with non-retryable error, keeping cached config and notifying observers: \(error)",
-                        tags: ["backgroundRefresh"])
-                    self.notifyConfigUpdated(error: error)
-                } else {
-                    Log.warn(
-                        "Background refresh failed with transient error, keeping cached config: \(error)",
-                        tags: ["backgroundRefresh"])
-                }
-            } else if let config = config {
-                self.updateUserConfig(config)
-                self.syncUserToEdgeDBIfEnabled(user: user, config: config)
-                self.notifyConfigUpdated(error: nil)
-            } else {
-                Log.warn(
-                    "Background refresh returned nil config with no error",
-                    tags: ["backgroundRefresh"])
-            }
         }
     }
 
@@ -523,16 +478,6 @@ public class DevCycleClient {
                         "Error getting config: \(error) for user_id \(String(describing: updateUser.userId))",
                         tags: ["identify"])
 
-                    if self.isNonRetryableError(error) {
-                        self.cacheService.clearConfigForUser(user: updateUser)
-                        self.lastIdentifiedUser = previousUser
-                        Log.error(
-                            "Non-retryable error on identifyUser, clearing cache and restoring previous user: \(error)",
-                            tags: ["identify"])
-                        callback?(error, nil)
-                        return
-                    }
-
                     if self.useCachedConfigForUser(user: updateUser),
                         self.config?.getUserConfig() != nil
                     {
@@ -540,7 +485,6 @@ public class DevCycleClient {
                             "Using cached config for identifyUser due to network error: \(error)",
                             tags: ["identify"])
                         self.user = user
-                        self.performBackgroundRefresh()
                         callback?(nil, self.config?.getUserConfig()?.variables)
                         return
                     } else {
@@ -601,18 +545,6 @@ public class DevCycleClient {
 
                 if let error = error {
                     Log.error("Error getting config for resetUser: \(error)", tags: ["reset"])
-                    if self.isNonRetryableError(error) {
-                        self.cacheService.clearConfigForUser(user: anonUser)
-                        if let previousAnonUserId = cachedAnonUserId {
-                            self.cacheService.setAnonUserId(anonUserId: previousAnonUserId)
-                        }
-                        self.lastIdentifiedUser = previousUser
-                        Log.error(
-                            "Definitive error on resetUser, clearing anonymous user cache and restoring previous user: \(error)",
-                            tags: ["reset"])
-                        callback?(error, nil)
-                        return
-                    }
                     if let previousAnonUserId = cachedAnonUserId {
                         self.cacheService.setAnonUserId(anonUserId: previousAnonUserId)
                     }

--- a/DevCycle/Models/Cache.swift
+++ b/DevCycle/Models/Cache.swift
@@ -12,7 +12,6 @@ protocol CacheServiceProtocol {
     func clearAnonUserId()
     func saveConfig(user: DevCycleUser, configToSave: Data?)
     func getConfig(user: DevCycleUser) -> UserConfig?
-    func clearConfigForUser(user: DevCycleUser)
     func getOrCreateAnonUserId() -> String
     func migrateLegacyCache()
 }
@@ -57,11 +56,6 @@ class CacheService: CacheServiceProtocol {
 
         let expiryDate = currentTimeMs() + configCacheTTL
         defaults.set(expiryDate, forKey: "\(key)\(CacheKeys.expiryDateSuffix)")
-    }
-
-    func clearConfigForUser(user: DevCycleUser) {
-        let key = getConfigKeyPrefix(user: user)
-        cleanupCacheEntry(key: key)
     }
 
     func getConfig(user: DevCycleUser) -> UserConfig? {

--- a/DevCycleTests/Models/DevCycleClientTests.swift
+++ b/DevCycleTests/Models/DevCycleClientTests.swift
@@ -966,32 +966,6 @@ class DevCycleClientTest: XCTestCase {
         defaults.removeObject(forKey: newUserCacheKey)
     }
 
-    // MARK: - Cache-first initialization tests
-
-    func testSetupUsesCacheHitFastPathAndCallsCallbackAsynchronously() {
-        let callbackExpectation = XCTestExpectation(description: "onInitialized fires after build returns")
-        var buildReturned = false
-
-        let mockCacheService = MockCacheServiceWithConfig(userConfig: self.userConfig)
-        let authErrorService = MockAuthErrorService()
-
-        let client = try! self.builder.user(self.user).sdkKey("dvc_mobile_my_sdk_key").service(
-            authErrorService
-        ).build(onInitialized: nil)
-        client.cacheService = mockCacheService
-        client.config = DVCConfig(sdkKey: "dvc_mobile_my_sdk_key", user: self.user)
-
-        client.setup(service: authErrorService, callback: { _ in
-            XCTAssertTrue(buildReturned, "Callback should fire after setup() returns")
-            XCTAssertTrue(client.initialized, "Client should be initialized on cache hit")
-            callbackExpectation.fulfill()
-        })
-        buildReturned = true
-
-        wait(for: [callbackExpectation], timeout: 5.0)
-        client.close(callback: nil)
-    }
-
     func testCacheHitEstablishesSSEConnectionFromCachedSSEURL() {
         let setupExpectation = XCTestExpectation(description: "setup completes via cache")
 
@@ -1011,175 +985,12 @@ class DevCycleClientTest: XCTestCase {
             XCTAssertNil(error, "Setup should succeed via cached config")
             XCTAssertNotNil(
                 client.sseConnection,
-                "SSE connection should be established immediately on cache hit, even if the background refresh fails"
+                "SSE connection should be established from the cached SSE URL during setup"
             )
             setupExpectation.fulfill()
         })
 
         wait(for: [setupExpectation], timeout: 5.0)
-        client.close(callback: nil)
-    }
-
-    func testBackgroundRefreshWithAuthErrorKeepsCachedValuesUsable() {
-        let refreshExpectation = XCTestExpectation(description: "onConfigUpdated fires with error after auth failure")
-
-        let mockCacheService = MockCacheServiceWithConfig(userConfig: self.userConfig)
-        let authErrorService = MockAuthErrorService()
-
-        let client = try! self.builder.user(self.user).sdkKey("dvc_mobile_my_sdk_key").service(
-            authErrorService
-        ).build(onInitialized: nil)
-        client.cacheService = mockCacheService
-        client.config = DVCConfig(sdkKey: "dvc_mobile_my_sdk_key", user: self.user)
-
-        client.onConfigUpdated { error in
-            XCTAssertNotNil(error, "onConfigUpdated should receive an error on auth failure")
-            XCTAssertFalse(mockCacheService.clearConfigForUserCalled, "Persisted cache must not be cleared on background auth error")
-            XCTAssertTrue(client.hasUsableCachedConfig(), "hasUsableCachedConfig should remain true after auth error")
-            let boolVar = client.variable(key: "bool-var", defaultValue: false)
-            XCTAssertEqual(boolVar.value, true, "Cached value must still be served after a background auth error")
-            XCTAssertFalse(boolVar.isDefaulted, "Variable must not fall back to default after a background auth error")
-            refreshExpectation.fulfill()
-        }
-
-        client.setup(service: authErrorService, callback: { error in
-            XCTAssertNil(error, "Setup should succeed via cached config")
-        })
-
-        wait(for: [refreshExpectation], timeout: 5.0)
-        client.close(callback: nil)
-    }
-
-    func testBackgroundRefreshWithTransientErrorKeepsCache() {
-        let setupExpectation = XCTestExpectation(description: "setup completes via cache")
-        let noRefreshExpectation = XCTestExpectation(description: "onConfigUpdated not called on transient error")
-        noRefreshExpectation.isInverted = true
-
-        let mockCacheService = MockCacheServiceWithConfig(userConfig: self.userConfig)
-        let failedService = MockFailedConnectionService()
-
-        let client = try! self.builder.user(self.user).sdkKey("dvc_mobile_my_sdk_key").service(
-            failedService
-        ).build(onInitialized: nil)
-        client.cacheService = mockCacheService
-        client.config = DVCConfig(sdkKey: "dvc_mobile_my_sdk_key", user: self.user)
-
-        client.onConfigUpdated { _ in
-            noRefreshExpectation.fulfill()
-        }
-
-        client.setup(service: failedService, callback: { error in
-            XCTAssertNil(error, "Setup should succeed via cached config")
-            XCTAssertFalse(mockCacheService.clearConfigForUserCalled, "Cache should not be cleared on transient error")
-            setupExpectation.fulfill()
-        })
-
-        wait(for: [setupExpectation, noRefreshExpectation], timeout: 2.0)
-        client.close(callback: nil)
-    }
-
-    func testIdentifyUserWithAuthErrorClearsNewUserCacheAndRestoresPreviousUser() {
-        let setupExpectation = XCTestExpectation(description: "setup completes")
-        let identifyExpectation = XCTestExpectation(description: "identifyUser returns auth error")
-
-        let sequencedService = MockSequencedService(userConfig: self.userConfig)
-
-        let client = try! self.builder.user(self.user).sdkKey("dvc_mobile_my_sdk_key").service(
-            sequencedService
-        ).build(onInitialized: nil)
-        client.config = DVCConfig(sdkKey: "dvc_mobile_my_sdk_key", user: self.user)
-
-        client.setup(service: sequencedService, callback: { _ in
-            setupExpectation.fulfill()
-        })
-        wait(for: [setupExpectation], timeout: 5.0)
-
-        let mockCacheService = MockCacheServiceWithConfig(userConfig: self.userConfig)
-        client.cacheService = mockCacheService
-
-        do {
-            let newUser = try DevCycleUser.builder().userId("new_user").build()
-            try client.identifyUser(user: newUser, callback: { error, variables in
-                XCTAssertNotNil(error, "identifyUser should return error on auth failure")
-                XCTAssertNil(variables, "identifyUser should not return variables on auth failure")
-                XCTAssertEqual(client.lastIdentifiedUser?.userId, self.user.userId, "Previous user should be restored")
-                XCTAssertTrue(mockCacheService.clearConfigForUserCalled, "New user cache should be cleared")
-                XCTAssertEqual(mockCacheService.clearedUser?.userId, "new_user")
-                identifyExpectation.fulfill()
-            })
-        } catch {
-            XCTFail("identifyUser should not throw: \(error)")
-            identifyExpectation.fulfill()
-        }
-
-        wait(for: [identifyExpectation], timeout: 5.0)
-        client.close(callback: nil)
-    }
-
-    func testOnConfigUpdatedNotifiedOnBackgroundRefreshSuccess() {
-        let setupExpectation = XCTestExpectation(description: "setup completes via cache")
-        let refreshExpectation = XCTestExpectation(description: "onConfigUpdated fires with no error on success")
-
-        let mockCacheService = MockCacheServiceWithConfig(userConfig: self.userConfig)
-        let successService = MockService(userConfig: self.userConfig)
-
-        let client = try! self.builder.user(self.user).sdkKey("dvc_mobile_my_sdk_key").service(
-            successService
-        ).build(onInitialized: nil)
-        client.cacheService = mockCacheService
-        client.config = DVCConfig(sdkKey: "dvc_mobile_my_sdk_key", user: self.user)
-
-        client.onConfigUpdated { error in
-            XCTAssertNil(error, "onConfigUpdated should receive no error on successful refresh")
-            XCTAssertFalse(client.hasUsableCachedConfig(), "isConfigCached should be false after fresh fetch")
-            refreshExpectation.fulfill()
-        }
-
-        client.setup(service: successService, callback: { error in
-            XCTAssertNil(error)
-            setupExpectation.fulfill()
-        })
-
-        wait(for: [setupExpectation, refreshExpectation], timeout: 5.0)
-        client.close(callback: nil)
-    }
-
-    func testOnConfigUpdatedReceivesEventWhenRegisteredAfterRefreshCompletes() {
-        let setupExpectation = XCTestExpectation(description: "setup completes via cache")
-        let backgroundRefreshExpectation = XCTestExpectation(
-            description: "background getConfig completed (mock service)")
-        let refreshExpectation = XCTestExpectation(description: "buffered onConfigUpdated event is replayed to a late registrant")
-
-        let mockCacheService = MockCacheServiceWithConfig(userConfig: self.userConfig)
-        let successService = MockService(userConfig: self.userConfig)
-
-        successService.onGetConfigFinished = { [weak successService] in
-            guard let successService = successService,
-                successService.numberOfConfigCalls == 2
-            else { return }
-            backgroundRefreshExpectation.fulfill()
-        }
-
-        let client = try! self.builder.user(self.user).sdkKey("dvc_mobile_my_sdk_key").service(
-            successService
-        ).build(onInitialized: nil)
-        client.cacheService = mockCacheService
-        client.config = DVCConfig(sdkKey: "dvc_mobile_my_sdk_key", user: self.user)
-
-        client.setup(service: successService, callback: { error in
-            XCTAssertNil(error)
-            setupExpectation.fulfill()
-        })
-        // Wait until init and the cache-driven background refresh have both finished on the main queue,
-        // so onConfigUpdated registration exercises the buffered replay path
-        wait(for: [setupExpectation, backgroundRefreshExpectation], timeout: 5.0)
-
-        client.onConfigUpdated { error in
-            XCTAssertNil(error, "Buffered onConfigUpdated event should be replayed to a late registrant")
-            refreshExpectation.fulfill()
-        }
-
-        wait(for: [refreshExpectation], timeout: 5.0)
         client.close(callback: nil)
     }
 
@@ -1205,7 +1016,7 @@ class DevCycleClientTest: XCTestCase {
 
     func testRefetchConfigNotifiesObserversOnDefinitiveError() {
         // SSE-driven 401/403 must reach onConfigUpdated so observers can react
-        // to a revoked SDK key, matching the policy in performBackgroundRefresh.
+        // to a revoked SDK key.
         let authErrorService = MockAuthErrorService()
         let client = try! self.builder.user(self.user).sdkKey("my_sdk_key")
             .service(authErrorService).build(onInitialized: nil)
@@ -1221,67 +1032,6 @@ class DevCycleClientTest: XCTestCase {
 
         client.refetchConfig(sse: true, lastModified: 123, etag: "etag")
         wait(for: [observerExpectation], timeout: 2.0)
-        client.close(callback: nil)
-    }
-
-    func testBackgroundRefreshSyncsUserToEdgeDBWhenEnabled() {
-        // Regression: cache-hit skips the initial fetch, so EdgeDB sync must run on bg refresh.
-        let setupExpectation = XCTestExpectation(description: "setup completes via cache")
-        let saveEntityExpectation = XCTestExpectation(description: "saveEntity called on background refresh")
-
-        let edgeDBConfig = makeEdgeDBEnabledConfig()
-        let mockCacheService = MockCacheServiceWithConfig(userConfig: edgeDBConfig)
-        let buildService = MockFailedConnectionService()
-        let successService = MockService(userConfig: edgeDBConfig)
-
-        let options = DevCycleOptions.builder().enableEdgeDB(true).build()
-        let client = try! self.builder.user(self.user).sdkKey("dvc_mobile_my_sdk_key")
-            .options(options).service(buildService).build(onInitialized: nil)
-        client.cacheService = mockCacheService
-        client.config = DVCConfig(sdkKey: "dvc_mobile_my_sdk_key", user: self.user)
-
-        client.setup(service: successService, callback: { error in
-            XCTAssertNil(error)
-            setupExpectation.fulfill()
-        })
-
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-            XCTAssertEqual(successService.saveEntityCallCount, 1, "saveEntity must run after a successful background refresh when EdgeDB is enabled")
-            XCTAssertEqual(successService.userForSaveEntity?.userId, self.user.userId)
-            saveEntityExpectation.fulfill()
-        }
-
-        wait(for: [setupExpectation, saveEntityExpectation], timeout: 5.0)
-        client.close(callback: nil)
-    }
-
-    func testBackgroundRefreshSkipsEdgeDBForAnonymousUser() {
-        // EdgeDB only persists identified users; anonymous users must never be synced.
-        let setupExpectation = XCTestExpectation(description: "setup completes via cache")
-        let noSaveExpectation = XCTestExpectation(description: "saveEntity not called for anon user")
-
-        let edgeDBConfig = makeEdgeDBEnabledConfig()
-        let mockCacheService = MockCacheServiceWithConfig(userConfig: edgeDBConfig)
-        let buildService = MockFailedConnectionService()
-        let successService = MockService(userConfig: edgeDBConfig)
-        let anonUser = try! DevCycleUser.builder().isAnonymous(true).build()
-
-        let options = DevCycleOptions.builder().enableEdgeDB(true).build()
-        let client = try! self.builder.user(anonUser).sdkKey("dvc_mobile_my_sdk_key")
-            .options(options).service(buildService).build(onInitialized: nil)
-        client.cacheService = mockCacheService
-        client.config = DVCConfig(sdkKey: "dvc_mobile_my_sdk_key", user: anonUser)
-
-        client.setup(service: successService, callback: { _ in
-            setupExpectation.fulfill()
-        })
-
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-            XCTAssertEqual(successService.saveEntityCallCount, 0, "Anonymous users must not be synced to EdgeDB")
-            noSaveExpectation.fulfill()
-        }
-
-        wait(for: [setupExpectation, noSaveExpectation], timeout: 5.0)
         client.close(callback: nil)
     }
 
@@ -1305,39 +1055,6 @@ extension DevCycleClientTest {
         ) {
             DispatchQueue.main.async {
                 completion((nil, APIError.StatusResponse(status: 401, message: "Unauthorized")))
-            }
-        }
-        func publishEvents(events: [DevCycleEvent], user: DevCycleUser, completion: @escaping PublishEventsCompletionHandler) {
-            DispatchQueue.main.async { completion((nil, nil, nil)) }
-        }
-        func saveEntity(user: DevCycleUser, completion: @escaping SaveEntityCompletionHandler) {
-            DispatchQueue.main.async { completion((nil, nil, nil)) }
-        }
-        func makeRequest(request: URLRequest, completion: @escaping DevCycle.CompletionHandler) {
-            DispatchQueue.main.async { completion((nil, nil, nil)) }
-        }
-    }
-
-    /// First getConfig succeeds; all subsequent calls return 401.
-    private class MockSequencedService: DevCycleServiceProtocol {
-        private let userConfig: UserConfig
-        private var callCount = 0
-
-        init(userConfig: UserConfig) {
-            self.userConfig = userConfig
-        }
-
-        func getConfig(
-            user: DevCycleUser, enableEdgeDB: Bool, extraParams: RequestParams?,
-            completion: @escaping ConfigCompletionHandler
-        ) {
-            callCount += 1
-            if callCount == 1 {
-                DispatchQueue.main.async { completion((self.userConfig, nil)) }
-            } else {
-                DispatchQueue.main.async {
-                    completion((nil, APIError.StatusResponse(status: 401, message: "Unauthorized")))
-                }
             }
         }
         func publishEvents(events: [DevCycleEvent], user: DevCycleUser, completion: @escaping PublishEventsCompletionHandler) {
@@ -1477,8 +1194,6 @@ extension DevCycleClientTest {
 
     private class MockCacheServiceWithConfig: CacheServiceProtocol {
         private let userConfig: UserConfig
-        var clearConfigForUserCalled = false
-        var clearedUser: DevCycleUser?
 
         init(userConfig: UserConfig) {
             self.userConfig = userConfig
@@ -1490,10 +1205,6 @@ extension DevCycleClientTest {
         func saveConfig(user: DevCycleUser, configToSave: Data?) {}
         func getConfig(user: DevCycleUser) -> UserConfig? {
             return self.userConfig
-        }
-        func clearConfigForUser(user: DevCycleUser) {
-            clearConfigForUserCalled = true
-            clearedUser = user
         }
         func getOrCreateAnonUserId() -> String {
             return "mock-anon-id"

--- a/DevCycleTests/Networking/DevCycleServiceTests.swift
+++ b/DevCycleTests/Networking/DevCycleServiceTests.swift
@@ -136,7 +136,6 @@ class DevCycleServiceTests: XCTestCase {
 extension DevCycleServiceTests {
     class MockCacheService: CacheServiceProtocol {
         var saveConfigCalled = false
-        var clearConfigForUserCalled = false
 
         func setAnonUserId(anonUserId: String) {
             // TODO: update implementation for tests
@@ -154,10 +153,6 @@ extension DevCycleServiceTests {
 
         func getConfig(user: DevCycleUser) -> UserConfig? {
             return nil
-        }
-
-        func clearConfigForUser(user: DevCycleUser) {
-            clearConfigForUserCalled = true
         }
 
         func getOrCreateAnonUserId() -> String {


### PR DESCRIPTION
## Summary

- `setup()` reverted to always await the network call before resolving the init callback. Cache is still loaded into memory early so variables are readable during the init window, but `onClientInitialized` doesn't resolve until a network response or definitive failure.
- `performBackgroundRefresh()` removed.
- Non-retryable-error cache-clearing branches removed from `identifyUser` and `resetUser`. The auth-error rollback work will be re-implemented in a follow-up PR.
- `CacheService.clearConfigForUser` removed (no callers after the above).

## Motivation

PR #261 changed the `onClientInitialized` contract silently: on a cache hit, the callback now resolves before the network call completes. Any app that awaits `onClientInitialized` and immediately reads variables now gets cached values rather than fresh ones, with no opt-in.

The motivating use case — `PROVIDER_READY` firing immediately from cache in the OpenFeature provider — can be served at the provider layer using the additive APIs added in #261, without changing the base SDK contract. See ios-openfeature-provider for the follow-up provider PR.

## What stays from #261

The additive APIs introduced in v1.25.0 are all retained:

- `hasUsableCachedConfig()` — `true` while the in-memory config is from cache and hasn't been replaced by a successful network response
- `onConfigUpdated(_:)` — observer with replay buffer, fired by `refetchConfig` on success or definitive error (SSE-triggered updates)
- `APIError.isNonRetryableError` (still used by `refetchConfig`)
- SSE connection established from the cached URL in `useCachedConfigForUser`
- `deliverInitializationComplete` and `syncUserToEdgeDBIfEnabled` helpers

## Related

- Reverts the contract change from #261
- Follow-up: OpenFeature provider PR (ios-openfeature-provider) will implement cache-first `PROVIDER_READY` at the provider layer using `hasUsableCachedConfig()` and `onConfigUpdated(_:)`
- Follow-up: re-implement auth-error rollback in `identifyUser`/`resetUser` in a separate PR