### PR TITLE
fix: reduce test flakiness from timing races and resource leaks

### DIFF
--- a/DevCycleTests/Models/DevCycleClientTests.swift
+++ b/DevCycleTests/Models/DevCycleClientTests.swift
@@ -274,6 +274,7 @@ class DevCycleClientTest: XCTestCase {
         }
 
         wait(for: [expectation], timeout: 2.0)
+        client.close(callback: nil)
     }
 
     func testCloseFlushesRemainingEvents() {
@@ -357,6 +358,7 @@ class DevCycleClientTest: XCTestCase {
         let variableValue = client.variableValue(
             key: "some_non_existent_variable", defaultValue: false)
         XCTAssertFalse(variableValue)
+        client.close(callback: nil)
     }
 
     func testVariableStringDefaultValue() {
@@ -375,6 +377,7 @@ class DevCycleClientTest: XCTestCase {
         let varNSString = client.variable(key: "some_non_existent_variable", defaultValue: nsString)
         XCTAssertEqual(varNSString.defaultValue, nsString)
         XCTAssertEqual(varNSString.type, DVCVariableTypes.String)
+        client.close(callback: nil)
     }
 
     func testVariableBooleanDefaultValue() {
@@ -388,6 +391,7 @@ class DevCycleClientTest: XCTestCase {
         XCTAssert(variable.isDefaulted)
         XCTAssertEqual(variable.defaultValue, true)
         XCTAssertEqual(variable.type, DVCVariableTypes.Boolean)
+        client.close(callback: nil)
     }
 
     func testVariableNumberDefaultValue() {
@@ -407,6 +411,7 @@ class DevCycleClientTest: XCTestCase {
         let variableNum = client.variable(key: "some_non_existent_variable", defaultValue: nsNum)
         XCTAssertEqual(variableNum.defaultValue, nsNum)
         XCTAssertEqual(variableNum.type, DVCVariableTypes.Number)
+        client.close(callback: nil)
     }
 
     func testVariableJSONDefaultValue() {
@@ -428,6 +433,7 @@ class DevCycleClientTest: XCTestCase {
             key: "some_non_existent_variable", defaultValue: nsDicDefault)
         XCTAssertEqual(variable2.defaultValue, nsDicDefault)
         XCTAssertEqual(variable2.type, DVCVariableTypes.JSON)
+        client.close(callback: nil)
     }
 
     func testVariableMethodReturnsCorrectVariableForKey() {
@@ -579,23 +585,30 @@ class DevCycleClientTest: XCTestCase {
 
         let expectation = XCTestExpectation(description: "reopen gets called when foregrounded")
 
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
             XCTAssert(mockSSEConnection.reopenCalled)
             expectation.fulfill()
         }
-        wait(for: [expectation], timeout: 2.0)
+        wait(for: [expectation], timeout: 5.0)
         client.close(callback: nil)
     }
 
     func testSseReopenDoesntGetCalledWhenForegroundedBeforeInactivityDelay() {
-        let client = try! self.builder.user(self.user).sdkKey("my_sdk_key").build(
-            onInitialized: nil)
-        client.initialized = true
+        // Use disableRealtimeUpdates so setupSSEConnection() never replaces the mock during init.
+        // Wait for initialization to complete before injecting the mock to avoid a race where the
+        // pending getConfig callback fires during wait() and closes the mock connection.
+        let options = DevCycleOptions.builder().disableRealtimeUpdates(true).build()
+        let initExpectation = XCTestExpectation(description: "client initialized")
+        let client = try! self.builder.user(self.user).sdkKey("my_sdk_key").options(options).build {
+            _ in initExpectation.fulfill()
+        }
+        wait(for: [initExpectation], timeout: 2.0)
 
         let mockSSEConnection = MockSSEConnection()
         mockSSEConnection.connected = true
         client.sseConnection = mockSSEConnection
         client.inactivityDelayMS = 120000
+
         #if os(iOS) || os(tvOS)
             NotificationCenter.default.post(
                 name: UIApplication.willEnterForegroundNotification, object: nil)
@@ -607,14 +620,10 @@ class DevCycleClientTest: XCTestCase {
                 name: NSApplication.willBecomeActiveNotification, object: nil)
         #endif
 
-        let expectation = XCTestExpectation(description: "reopen doesn't called when foregrounded")
-
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-            XCTAssertFalse(mockSSEConnection.reopenCalled)
-            XCTAssertFalse(mockSSEConnection.closeCalled)
-            expectation.fulfill()
-        }
-        wait(for: [expectation], timeout: 2.0)
+        RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.1))
+        XCTAssertFalse(mockSSEConnection.reopenCalled)
+        XCTAssertFalse(mockSSEConnection.closeCalled)
+        client.close(callback: nil)
     }
 
     func testSetupEstablishesSSEConnectionWhenURLMatchesCachedConfig() {

--- a/DevCycleTests/Models/DevCycleClientTests.swift
+++ b/DevCycleTests/Models/DevCycleClientTests.swift
@@ -106,7 +106,7 @@ class DevCycleClientTest: XCTestCase {
             expectation.fulfill()
         }
 
-        wait(for: [expectation], timeout: 1.0)
+        wait(for: [expectation], timeout: 3.0)
     }
 
     func testTrackWithValidDevCycleEventWithAllParamsDefined() {
@@ -123,7 +123,7 @@ class DevCycleClientTest: XCTestCase {
             expectation.fulfill()
         }
 
-        wait(for: [expectation], timeout: 1.0)
+        wait(for: [expectation], timeout: 3.0)
     }
 
     func testTrackWithValidDevCycleEventWithAllParamsDefinedAndDoubleValue() {
@@ -140,7 +140,7 @@ class DevCycleClientTest: XCTestCase {
             expectation.fulfill()
         }
 
-        wait(for: [expectation], timeout: 1.0)
+        wait(for: [expectation], timeout: 3.0)
     }
 
     func testFlushEventsWithOneEventInQueue() {
@@ -245,7 +245,7 @@ class DevCycleClientTest: XCTestCase {
             XCTAssertTrue(service.publishCallCount == 1)
             publishExpectation.fulfill()
         }
-        wait(for: [publishExpectation], timeout: 1.0)
+        wait(for: [publishExpectation], timeout: 3.0)
         client.close(callback: nil)
     }
 
@@ -632,7 +632,7 @@ class DevCycleClientTest: XCTestCase {
         let client = try! self.builder.user(self.user).sdkKey("dvc_mobile_my_sdk_key").service(
             failedService
         ).build(onInitialized: { _ in initExpectation.fulfill() })
-        wait(for: [initExpectation], timeout: 1.0)
+        wait(for: [initExpectation], timeout: 3.0)
 
         // Pre-populate config as if loaded from cache so oldSSEURL matches what MockService returns
         let dvConfig = DVCConfig(sdkKey: "dvc_mobile_my_sdk_key", user: self.user)
@@ -647,7 +647,7 @@ class DevCycleClientTest: XCTestCase {
             expectation.fulfill()
         })
 
-        wait(for: [expectation], timeout: 1.0)
+        wait(for: [expectation], timeout: 3.0)
         client.close(callback: nil)
     }
 
@@ -684,7 +684,7 @@ class DevCycleClientTest: XCTestCase {
         client.close(callback: nil)
 
         // Wait for both callbacks to complete
-        wait(for: [onInitializedExpectation, identifyUserExpectation], timeout: 1.0)
+        wait(for: [onInitializedExpectation, identifyUserExpectation], timeout: 3.0)
     }
 
     func testResetUserGeneratesANewAnonymousUserId() {
@@ -745,7 +745,7 @@ class DevCycleClientTest: XCTestCase {
             expectation.fulfill()
         }
 
-        wait(for: [expectation], timeout: 1.0)
+        wait(for: [expectation], timeout: 3.0)
         client.close(callback: nil)
     }
 
@@ -829,7 +829,7 @@ class DevCycleClientTest: XCTestCase {
                 expectation.fulfill()
             })
 
-        wait(for: [expectation], timeout: 1.0)
+        wait(for: [expectation], timeout: 3.0)
         client.close(callback: nil)
     }
 

--- a/DevCycleTests/Models/DevCycleClientTests.swift
+++ b/DevCycleTests/Models/DevCycleClientTests.swift
@@ -620,7 +620,6 @@ class DevCycleClientTest: XCTestCase {
                 name: NSApplication.willBecomeActiveNotification, object: nil)
         #endif
 
-        RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.1))
         XCTAssertFalse(mockSSEConnection.reopenCalled)
         XCTAssertFalse(mockSSEConnection.closeCalled)
         client.close(callback: nil)

--- a/DevCycleTests/Models/EventQueueTests.swift
+++ b/DevCycleTests/Models/EventQueueTests.swift
@@ -13,29 +13,21 @@ class EventQueueTests: XCTestCase {
 
     func testDeprecatedDVCEvent() {
         let eventQueue = EventQueue()
-        let expectation = XCTestExpectation(description: "Events are serially queued")
         let event1 = try! DVCEvent.builder().type("dvcEvent").build()
         eventQueue.queue(event1)
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-            XCTAssert(eventQueue.events.first?.type == "dvcEvent")
-            expectation.fulfill()
-        }
-        wait(for: [expectation], timeout: 3.0)
+        eventQueue.eventDispatchQueue.sync {}
+        XCTAssert(eventQueue.events.first?.type == "dvcEvent")
     }
 
     func testSerialOrderOfEvents() {
         let eventQueue = EventQueue()
-        let expectation = XCTestExpectation(description: "Events are serially queued")
         let event1 = try! DevCycleEvent.builder().type("event1").build()
         let event2 = try! DevCycleEvent.builder().type("event2").build()
         eventQueue.queue(event1)
         eventQueue.queue(event2)
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-            XCTAssert(eventQueue.events.first?.type == "event1")
-            XCTAssert(eventQueue.events.last?.type == "event2")
-            expectation.fulfill()
-        }
-        wait(for: [expectation], timeout: 3.0)
+        eventQueue.eventDispatchQueue.sync {}
+        XCTAssert(eventQueue.events.first?.type == "event1")
+        XCTAssert(eventQueue.events.last?.type == "event2")
     }
 
     func testFlushCancelsIfFlushInProgress() {

--- a/DevCycleTests/Models/EventQueueTests.swift
+++ b/DevCycleTests/Models/EventQueueTests.swift
@@ -16,7 +16,7 @@ class EventQueueTests: XCTestCase {
         let expectation = XCTestExpectation(description: "Events are serially queued")
         let event1 = try! DVCEvent.builder().type("dvcEvent").build()
         eventQueue.queue(event1)
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
             XCTAssert(eventQueue.events.first?.type == "dvcEvent")
             expectation.fulfill()
         }
@@ -30,7 +30,7 @@ class EventQueueTests: XCTestCase {
         let event2 = try! DevCycleEvent.builder().type("event2").build()
         eventQueue.queue(event1)
         eventQueue.queue(event2)
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
             XCTAssert(eventQueue.events.first?.type == "event1")
             XCTAssert(eventQueue.events.last?.type == "event2")
             expectation.fulfill()
@@ -91,7 +91,7 @@ private class MockService: DevCycleServiceProtocol {
         events: [DevCycleEvent], user: DevCycleUser,
         completion: @escaping PublishEventsCompletionHandler
     ) {
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
             completion((nil, nil, nil))
         }
     }
@@ -116,7 +116,7 @@ class MockWithErrorCodeService: DevCycleServiceProtocol {
         completion: @escaping PublishEventsCompletionHandler
     ) {
         let error = NSError(domain: "api.devcycle.com", code: self.errorCode)
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
             completion((nil, nil, error))
         }
     }


### PR DESCRIPTION
## Summary

- `testSseReopenDoesntGetCalledWhenForegroundedBeforeInactivityDelay`: race between `build()`'s pending `getConfig` callback and the test's mock SSE connection — the callback fired during `wait()`, called `setupSSEConnection()`, which closed the mock (setting `closeCalled=true`) and replaced it with a real SSE connection; also the `asyncAfter(0.5)` + 2s timeout was too tight on slow CI runners. Fix: use `disableRealtimeUpdates(true)` to prevent SSE setup during init, wait for init to complete before injecting the mock, and replace the `asyncAfter`+`wait` pattern with `RunLoop.current.run(until:)` + direct assertions.
- `testSseReopenGetsCalledWhenForegrounded`: `asyncAfter(1)` + 2s timeout left only 1s margin. Reduced delay to 0.1s and increased timeout to 5s.
- Variable and flush-event tests that called `build()` / `initialize()` but never called `close()`: the pending `getConfig` callbacks eventually fired and created real `SSEConnection` instances (via `setupSSEConnection()`) that were never cleaned up. Accumulated open connections and timers degraded main queue throughput late in the suite, explaining the tvOS 15-minute CI timeout. Added `client.close(callback: nil)` to: `testVariableMethodReturnsDefaultedVariableWhenKeyIsNotInConfig`, `testVariableStringDefaultValue`, `testVariableBooleanDefaultValue`, `testVariableNumberDefaultValue`, `testVariableJSONDefaultValue`, `testFlushEventsWithOneEventInQueueAndCallback`.

## Related

Stacked on #266