### PR TITLE
chore: resolve open dependabot security alerts

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,7 +43,7 @@ GEM
     dotenv (2.8.1)
     emoji_regex (3.2.3)
     excon (0.112.0)
-    faraday (1.10.5)
+    faraday (1.10.6)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
       faraday-excon (~> 1.1)


### PR DESCRIPTION
## Summary

- Bumped `faraday` from 1.10.5 to 1.10.6 to resolve high-severity vulnerability (alert #17): Uncontrolled recursion in NestedParamsEncoder allows stack exhaustion DoS via deeply nested query parameters

## Dependabot Alerts Resolved

| Alert | Package | Severity | Fix |
|-------|---------|----------|-----|
| #17 | `faraday` | **high** | Bumped to 1.10.6 in Gemfile.lock (transitive dep via fastlane) |