### PR TITLE
chore: resolve open dependabot security alerts

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -173,7 +173,7 @@ GEM
     httpclient (2.9.0)
       mutex_m
     jmespath (1.6.2)
-    json (2.21.1)
+    json (2.21.2)
     jwt (3.2.0)
       base64
     logger (1.7.0)


### PR DESCRIPTION
## Summary

- Bumped `json` gem from 2.21.1 to 2.21.2 to resolve a low-severity vulnerability (JSON::ResumableParser#partial_value dereferences a freed input buffer and crashes on truncated duplicate-key streams, alert #20)